### PR TITLE
Enable react router v7 future flags

### DIFF
--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -18,7 +18,12 @@ const queryClient = new QueryClient({
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
+      <BrowserRouter
+        future={{
+          v7_startTransition: true,
+          v7_relativeSplatPath: true,
+        }}
+      >
         <App />
       </BrowserRouter>
     </QueryClientProvider>


### PR DESCRIPTION
Enable React Router v7 future flags (`v7_startTransition`, `v7_relativeSplatPath`) to address deprecation warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-fcec6aa1-5c8c-4dcc-9f5a-872c09f9ba3b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fcec6aa1-5c8c-4dcc-9f5a-872c09f9ba3b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

