### PR TITLE
Enable react router v7 future flags

### DIFF
--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { BrowserRouter } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import App from './App';
 import './styles/global.css';
 import 'monaco-editor/min/vs/editor/editor.main.css';
@@ -15,12 +15,26 @@ const queryClient = new QueryClient({
   },
 });
 
+// Create router with future flags enabled
+const router = createBrowserRouter(
+  [
+    {
+      path: '/*',
+      element: <App />,
+    },
+  ],
+  {
+    future: {
+      v7_startTransition: true,
+      v7_relativeSplatPath: true,
+    },
+  }
+);
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <RouterProvider router={router} />
     </QueryClientProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
Migrate to `createBrowserRouter` and `RouterProvider` to resolve React Router v7 future flag deprecation warnings.

The existing `BrowserRouter` setup was triggering warnings about upcoming React Router v7 changes regarding `React.startTransition` and relative splat path resolution. This PR enables the `v7_startTransition` and `v7_relativeSplatPath` future flags by switching to the data router API (`createBrowserRouter` and `RouterProvider`), ensuring compatibility and preparing for the v7 upgrade.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f7d31e6-db03-4bbf-8435-9e01de5674d4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7f7d31e6-db03-4bbf-8435-9e01de5674d4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

