### PR TITLE
Fix insecure content security policy

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -42,34 +42,25 @@ function createWindow() {
     show: false,
   });
 
-  // Disable Content Security Policy in development mode to allow API calls
-  if (!isDev) {
-    // Only apply CSP in production
-    mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
-      callback({
-        responseHeaders: {
-          ...details.responseHeaders,
-          'Content-Security-Policy': [
-            "default-src 'self' https://api.github.com; " +
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
-            "style-src 'self' 'unsafe-inline'; " +
-            "img-src 'self' data: https://avatars.githubusercontent.com https://github.com https://*.githubusercontent.com; " +
-            "font-src 'self' data:; " +
-            "connect-src 'self' https://api.github.com https://github.com http://localhost:* ws://localhost:*; " +
-            "worker-src 'self' blob:;"
-          ]
-        }
-      });
+  // Apply a strict Content Security Policy for all environments
+  mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
+    const contentSecurityPolicy = [
+      "default-src 'self' https://api.github.com;",
+      "script-src 'self' 'unsafe-inline';", // removed 'unsafe-eval'
+      "style-src 'self' 'unsafe-inline';",
+      "img-src 'self' data: https://avatars.githubusercontent.com https://github.com https://*.githubusercontent.com;",
+      "font-src 'self' data:;",
+      "connect-src 'self' https://api.github.com https://github.com http://localhost:* ws://localhost:*;",
+      "worker-src 'self' blob:;"
+    ].join(' ');
+
+    callback({
+      responseHeaders: {
+        ...details.responseHeaders,
+        'Content-Security-Policy': [contentSecurityPolicy]
+      }
     });
-  } else {
-    // Remove CSP entirely in development
-    mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
-      const responseHeaders = { ...details.responseHeaders };
-      delete responseHeaders['Content-Security-Policy'];
-      delete responseHeaders['content-security-policy'];
-      callback({ responseHeaders });
-    });
-  }
+  });
 
   // Show window when ready
   mainWindow.once('ready-to-show', () => {


### PR DESCRIPTION
Remove `'unsafe-eval'` from the Content Security Policy and unify its application to resolve Electron security warnings.

The previous CSP configuration either disabled the policy in development or included `'unsafe-eval'` in production, triggering Electron's security warning. This change applies a single, stricter CSP across all environments, removing `'unsafe-eval'` while ensuring necessary allowances for development (e.g., `localhost` connections, inline styles) are maintained.

---
<a href="https://cursor.com/background-agent?bcId=bc-17cf9b8e-71f7-43f7-a13e-9ea9a30647be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-17cf9b8e-71f7-43f7-a13e-9ea9a30647be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

