### PR TITLE
Fix insecure content security policy

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- CSP is handled by Electron main process -->
+    <!-- CSP is primarily handled by Electron main process, but this provides a fallback -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" />
     <title>Bottleneck - GitHub PR Review</title>
   </head>
   <body>


### PR DESCRIPTION
Implement Content Security Policy for both development and production to resolve Electron security warnings and enhance application security.

The original setup either completely removed CSP in development, leading to Electron warnings, or used `unsafe-eval` in production, which is a security risk. This PR introduces a development-specific CSP that balances security with development needs (e.g., hot reloading) and a more restrictive, secure CSP for production by removing `unsafe-eval` and adding further directives. A fallback CSP meta tag is also added to `index.html`.

---
<a href="https://cursor.com/background-agent?bcId=bc-86870b80-1ed2-4b15-9015-184f44b77836">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86870b80-1ed2-4b15-9015-184f44b77836">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

