### PR TITLE
Fix insecure content security policy

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- CSP is handled by Electron main process -->
+    <!-- Content Security Policy - configured by Electron main process, this is a fallback -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://avatars.githubusercontent.com https://github.com https://*.githubusercontent.com; font-src 'self' data:; connect-src 'self' https://api.github.com https://github.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self';">
     <title>Bottleneck - GitHub PR Review</title>
   </head>
   <body>


### PR DESCRIPTION
Refactor Content Security Policy to remove `unsafe-eval` and apply consistent, enhanced security headers for both development and production.

---
<a href="https://cursor.com/background-agent?bcId=bc-edeb4b7f-999f-45e3-bf46-6e21050858ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-edeb4b7f-999f-45e3-bf46-6e21050858ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

