### PR TITLE
Fix insecure content security policy

### DIFF
--- a/src/main/auth.ts
+++ b/src/main/auth.ts
@@ -97,6 +97,7 @@ export class GitHubAuth {
       <html>
         <head>
           <title>Enter GitHub Token</title>
+          <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; frame-ancestors 'none'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self'">
           <style>
             body {
               font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -176,7 +177,7 @@ export class GitHubAuth {
           <h2>Enter GitHub Personal Access Token</h2>
           <p>
             Paste your GitHub Personal Access Token below. 
-            Need to create one? <a href="#" onclick="require('electron').shell.openExternal('https://github.com/settings/tokens/new?description=Bottleneck%20App&scopes=repo,read:org,read:user,workflow'); return false;">Create token on GitHub</a>
+            Need to create one? <a id="create-token" href="https://github.com/settings/tokens/new?description=Bottleneck%20App&scopes=repo,read:org,read:user,workflow" rel="noreferrer noopener">Create token on GitHub</a>
           </p>
           <input 
             type="password" 
@@ -190,13 +191,20 @@ export class GitHubAuth {
             <button class="primary" onclick="submitToken()">Authenticate</button>
           </div>
           <script>
-            const { ipcRenderer } = require('electron');
-            
+            const { ipcRenderer, shell } = require('electron');
+            (function(){
+              const link = document.getElementById('create-token');
+              if (link) {
+                link.addEventListener('click', function(e){
+                  e.preventDefault();
+                  shell.openExternal(link.href);
+                });
+              }
+            })();
             function submitToken() {
               const token = document.getElementById('token').value;
               ipcRenderer.send('token-submitted', token);
             }
-            
             function cancel() {
               ipcRenderer.send('token-cancelled');
             }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -42,34 +42,40 @@ function createWindow() {
     show: false,
   });
 
-  // Disable Content Security Policy in development mode to allow API calls
-  if (!isDev) {
-    // Only apply CSP in production
-    mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
-      callback({
-        responseHeaders: {
-          ...details.responseHeaders,
-          'Content-Security-Policy': [
-            "default-src 'self' https://api.github.com; " +
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
-            "style-src 'self' 'unsafe-inline'; " +
-            "img-src 'self' data: https://avatars.githubusercontent.com https://github.com https://*.githubusercontent.com; " +
-            "font-src 'self' data:; " +
-            "connect-src 'self' https://api.github.com https://github.com http://localhost:* ws://localhost:*; " +
-            "worker-src 'self' blob:;"
-          ]
-        }
-      });
+  // Apply a secure Content Security Policy in all environments
+  // Note: avoid 'unsafe-eval'; allow websocket localhost only in development
+  const csp = isDev
+    ? [
+        "default-src 'self'; ",
+        "base-uri 'self'; ",
+        "frame-ancestors 'none'; ",
+        "img-src 'self' data: https://avatars.githubusercontent.com https://github.com https://*.githubusercontent.com; ",
+        "font-src 'self' data:; ",
+        "style-src 'self' 'unsafe-inline'; ",
+        "script-src 'self'; ",
+        "connect-src 'self' https://api.github.com https://github.com http://localhost:* ws://localhost:*; ",
+        "worker-src 'self' blob:;"
+      ].join('')
+    : [
+        "default-src 'self' https://api.github.com; ",
+        "base-uri 'self'; ",
+        "frame-ancestors 'none'; ",
+        "img-src 'self' data: https://avatars.githubusercontent.com https://github.com https://*.githubusercontent.com; ",
+        "font-src 'self' data:; ",
+        "style-src 'self' 'unsafe-inline'; ",
+        "script-src 'self'; ",
+        "connect-src 'self' https://api.github.com https://github.com; ",
+        "worker-src 'self' blob:;"
+      ].join('');
+
+  mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
+    callback({
+      responseHeaders: {
+        ...details.responseHeaders,
+        'Content-Security-Policy': [csp]
+      }
     });
-  } else {
-    // Remove CSP entirely in development
-    mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
-      const responseHeaders = { ...details.responseHeaders };
-      delete responseHeaders['Content-Security-Policy'];
-      delete responseHeaders['content-security-policy'];
-      callback({ responseHeaders });
-    });
-  }
+  });
 
   // Show window when ready
   mainWindow.once('ready-to-show', () => {


### PR DESCRIPTION
Enforce a strict Content Security Policy across all environments and for the token modal to resolve Electron security warnings.

The previous CSP configuration either disabled CSP in development or allowed `unsafe-eval` in production, triggering Electron's security warnings. The token modal, rendered via a `data:` URL, also lacked a CSP. This PR applies a consistent, secure CSP and refactors inline scripts in the modal to meet the stricter policy.

---
<a href="https://cursor.com/background-agent?bcId=bc-e68ad86b-409a-4958-b775-5a05b5327902">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e68ad86b-409a-4958-b775-5a05b5327902">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

