### PR TITLE
Fix insecure content security policy

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -42,32 +42,39 @@ function createWindow() {
     show: false,
   });
 
-  // Disable Content Security Policy in development mode to allow API calls
-  if (!isDev) {
-    // Only apply CSP in production
+  // Apply strict Content Security Policy in both development and production
+  {
+    const devCsp =
+      "default-src 'self'; " +
+      "script-src 'self' blob:; " +
+      "style-src 'self' 'unsafe-inline'; " +
+      "img-src 'self' data: https://avatars.githubusercontent.com https://github.com https://*.githubusercontent.com; " +
+      "font-src 'self' data:; " +
+      "connect-src 'self' http://localhost:* ws://localhost:* https://api.github.com https://github.com; " +
+      "worker-src 'self' blob:; " +
+      "object-src 'none'; " +
+      "base-uri 'none'; " +
+      "frame-ancestors 'none'";
+    const prodCsp =
+      "default-src 'self'; " +
+      "script-src 'self' blob:; " +
+      "style-src 'self' 'unsafe-inline'; " +
+      "img-src 'self' data: https://avatars.githubusercontent.com https://github.com https://*.githubusercontent.com; " +
+      "font-src 'self' data:; " +
+      "connect-src 'self' https://api.github.com https://github.com; " +
+      "worker-src 'self' blob:; " +
+      "object-src 'none'; " +
+      "base-uri 'none'; " +
+      "frame-ancestors 'none'";
+    const csp = isDev ? devCsp : prodCsp;
+
     mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
       callback({
         responseHeaders: {
           ...details.responseHeaders,
-          'Content-Security-Policy': [
-            "default-src 'self' https://api.github.com; " +
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
-            "style-src 'self' 'unsafe-inline'; " +
-            "img-src 'self' data: https://avatars.githubusercontent.com https://github.com https://*.githubusercontent.com; " +
-            "font-src 'self' data:; " +
-            "connect-src 'self' https://api.github.com https://github.com http://localhost:* ws://localhost:*; " +
-            "worker-src 'self' blob:;"
-          ]
+          'Content-Security-Policy': [csp]
         }
       });
-    });
-  } else {
-    // Remove CSP entirely in development
-    mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
-      const responseHeaders = { ...details.responseHeaders };
-      delete responseHeaders['Content-Security-Policy'];
-      delete responseHeaders['content-security-policy'];
-      callback({ responseHeaders });
     });
   }
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- CSP is handled by Electron main process -->
+    <!-- Fallback CSP for file:// loads; main process also sets CSP headers -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://avatars.githubusercontent.com https://github.com https://*.githubusercontent.com; font-src 'self' data:; connect-src 'self' http://localhost:* ws://localhost:* https://api.github.com https://github.com; worker-src 'self' blob:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'">
     <title>Bottleneck - GitHub PR Review</title>
   </head>
   <body>


### PR DESCRIPTION
Apply a strict Content Security Policy (CSP) to resolve the Electron security warning about `unsafe-eval` and enhance application security.

The previous configuration either disabled CSP in development or included `unsafe-eval` in production, triggering Electron's "Insecure Content-Security-Policy" warning. This PR enforces a strict CSP without `unsafe-eval` via HTTP headers in `src/main/index.ts` and adds a fallback meta tag in `src/renderer/index.html` to cover `file://` loads, ensuring consistent security.

---
<a href="https://cursor.com/background-agent?bcId=bc-dd22f000-1b59-4880-a29c-79dcd8f78038">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dd22f000-1b59-4880-a29c-79dcd8f78038">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

