### PR TITLE
Display github actions check status for branches

### DIFF
--- a/TEST_GITHUB_ACTIONS_STATUS.md
+++ b/TEST_GITHUB_ACTIONS_STATUS.md
@@ -1,0 +1,146 @@
+# GitHub Actions Check Status Feature - Testing Guide
+
+## Feature Overview
+The GitHub Actions check status feature allows users to view CI/CD pipeline status for each branch directly in the UI.
+
+## Implementation Details
+
+### Components Added
+1. **CheckStatusBadge.tsx** - Displays status icons (✓ passed, ✗ failed, ⟳ running, - no checks)
+2. **CheckStatusDetails.tsx** - Expandable panel showing detailed check results
+
+### API Integration
+- Extended `GitHubAPI` class with methods:
+  - `getCheckRunsForRef()` - Fetches check runs for a specific commit
+  - `getWorkflowRunsForBranch()` - Fetches workflow runs for a branch
+  - `getBranchCheckStatus()` - Gets overall status for a branch
+  - `getBatchBranchCheckStatuses()` - Batch fetches status for multiple branches
+
+### Store Updates
+- Enhanced `branchStore` with:
+  - `checkStatus` field in Branch interface
+  - `fetchBranchCheckStatuses()` method
+  - Check status caching (2-minute cache duration)
+
+### UI Features
+
+#### Status Indicators
+- **Green checkmark (✓)** - All checks passed
+- **Red X (✗)** - One or more checks failed
+- **Yellow spinner (⟳)** - Checks are running
+- **Gray circle (-)** - No checks configured
+
+#### Controls
+- **Checks toggle button** - Show/hide check status badges
+- **Status filter dropdown** - Filter branches by check status
+- **Auto-refresh dropdown** - Set automatic refresh interval (30s, 1m, 2m, 5m)
+- **Refresh button** - Manual refresh of branches and check status
+
+#### Expandable Details
+- Click on status badge to expand detailed view
+- Shows individual check runs grouped by status
+- Direct links to GitHub Actions logs
+- Timestamps for started/completed times
+
+#### Sorting & Filtering
+- Sort branches by check status (failures first)
+- Filter branches by status (All/Passed/Failed/Running/No checks)
+
+## Testing Steps
+
+### Prerequisites
+1. Ensure you have a GitHub token configured with appropriate permissions
+2. Select a repository that has GitHub Actions configured
+
+### Test Scenarios
+
+#### 1. Basic Display
+- [ ] Navigate to Branches view
+- [ ] Verify check status badges appear next to branch names
+- [ ] Confirm correct icons for different statuses
+
+#### 2. Expandable Details
+- [ ] Click on a check status badge
+- [ ] Verify detailed panel expands below the branch
+- [ ] Check that individual checks are listed with correct status
+- [ ] Verify "View on GitHub" links work
+
+#### 3. Filtering
+- [ ] Use the check status filter dropdown
+- [ ] Verify branches are filtered correctly for each option
+- [ ] Test "All checks", "Passed", "Failed", "Running", "No checks"
+
+#### 4. Sorting
+- [ ] Select "Check status" from Sort by dropdown
+- [ ] Verify branches are sorted with failures first, then pending, none, and success
+
+#### 5. Auto-refresh
+- [ ] Select "Refresh every 30s" from auto-refresh dropdown
+- [ ] Wait 30 seconds
+- [ ] Verify check statuses update automatically
+- [ ] Test other refresh intervals
+
+#### 6. Manual Refresh
+- [ ] Click the refresh button
+- [ ] Verify both branches and check statuses are refreshed
+- [ ] Check loading spinner appears during refresh
+
+#### 7. Toggle Check Status
+- [ ] Click the "Checks" toggle button
+- [ ] Verify check status badges hide/show
+- [ ] Confirm filter and auto-refresh options hide when disabled
+
+## Acceptance Criteria Verification
+
+✅ **GitHub Actions check status is displayed for each branch**
+- Status badges show next to branch names
+- Different icons for success/failure/pending/none states
+
+✅ **Status updates automatically or on-demand**
+- Auto-refresh intervals available (30s, 1m, 2m, 5m)
+- Manual refresh button provided
+- 2-minute cache to prevent excessive API calls
+
+✅ **Users can view detailed check information**
+- Expandable details panel with individual check results
+- Shows check names, status, timestamps
+- Groups checks by status (Running, Failed, Passed, Other)
+
+✅ **Status indicators are clear and intuitive**
+- Color-coded badges (green=success, red=failure, yellow=pending, gray=none)
+- Tooltips show summary (e.g., "All 5 checks passed")
+- Clear icons that match GitHub's conventions
+
+✅ **Direct links to GitHub Actions logs are available**
+- Each check in details panel has external link icon
+- Links open GitHub Actions page in new tab
+
+## Additional Features Implemented
+
+- **Batch API calls** - Efficient fetching of status for multiple branches
+- **Caching** - Reduces API calls with 2-minute cache
+- **Progressive loading** - Branches load first, then check statuses
+- **Error handling** - Graceful fallback if API calls fail
+- **Theme support** - Works in both light and dark themes
+
+## Performance Considerations
+
+- Check statuses are fetched in batches of 5 branches to avoid rate limiting
+- Only fetches status for visible branches (respects current filters)
+- Caching prevents redundant API calls
+- Auto-refresh can be disabled to reduce API usage
+
+## Known Limitations
+
+1. GitHub API rate limits may affect large repositories
+2. Check status for very old branches might not be available
+3. Private repositories require appropriate token permissions
+4. Workflow runs are limited to 10 most recent per branch
+
+## Troubleshooting
+
+If check statuses don't appear:
+1. Verify GitHub token has `repo` and `actions:read` scopes
+2. Check browser console for API errors
+3. Ensure repository has GitHub Actions configured
+4. Try manual refresh to bypass cache

--- a/src/renderer/components/CheckStatusBadge.tsx
+++ b/src/renderer/components/CheckStatusBadge.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import { 
+  CheckCircle2, 
+  XCircle, 
+  Loader2, 
+  Circle,
+  AlertCircle,
+  Clock
+} from "lucide-react";
+import { cn } from "../utils/cn";
+import { BranchCheckStatus } from "../services/github";
+
+interface CheckStatusBadgeProps {
+  status?: BranchCheckStatus;
+  size?: "sm" | "md" | "lg";
+  showLabel?: boolean;
+  className?: string;
+  onClick?: () => void;
+}
+
+export const CheckStatusBadge: React.FC<CheckStatusBadgeProps> = ({
+  status,
+  size = "sm",
+  showLabel = false,
+  className,
+  onClick,
+}) => {
+  const getStatusIcon = () => {
+    const iconSize = size === "sm" ? 14 : size === "md" ? 16 : 20;
+    
+    if (!status) {
+      return <Circle className="text-gray-400" size={iconSize} />;
+    }
+
+    switch (status.overallStatus) {
+      case "success":
+        return <CheckCircle2 className="text-green-500" size={iconSize} />;
+      case "failure":
+        return <XCircle className="text-red-500" size={iconSize} />;
+      case "pending":
+        return <Loader2 className="text-yellow-500 animate-spin" size={iconSize} />;
+      case "none":
+      default:
+        return <Circle className="text-gray-400" size={iconSize} />;
+    }
+  };
+
+  const getStatusLabel = () => {
+    if (!status) return "No checks";
+    
+    switch (status.overallStatus) {
+      case "success":
+        return "Passed";
+      case "failure":
+        return "Failed";
+      case "pending":
+        return "Running";
+      case "none":
+      default:
+        return "No checks";
+    }
+  };
+
+  const getStatusColor = () => {
+    if (!status) return "text-gray-500";
+    
+    switch (status.overallStatus) {
+      case "success":
+        return "text-green-500";
+      case "failure":
+        return "text-red-500";
+      case "pending":
+        return "text-yellow-500";
+      case "none":
+      default:
+        return "text-gray-500";
+    }
+  };
+
+  const getTooltip = () => {
+    if (!status) return "No GitHub Actions checks";
+    
+    const totalChecks = status.checkRuns.length + status.workflowRuns.length;
+    
+    if (totalChecks === 0) {
+      return "No GitHub Actions checks configured";
+    }
+
+    const failedChecks = [
+      ...status.checkRuns.filter(r => r.conclusion === "failure"),
+      ...status.workflowRuns.filter(r => r.conclusion === "failure")
+    ];
+
+    const runningChecks = [
+      ...status.checkRuns.filter(r => r.status === "in_progress" || r.status === "queued"),
+      ...status.workflowRuns.filter(r => r.status === "in_progress" || r.status === "queued")
+    ];
+
+    if (status.overallStatus === "success") {
+      return `All ${totalChecks} check${totalChecks > 1 ? 's' : ''} passed`;
+    } else if (status.overallStatus === "failure") {
+      return `${failedChecks.length} of ${totalChecks} check${totalChecks > 1 ? 's' : ''} failed`;
+    } else if (status.overallStatus === "pending") {
+      return `${runningChecks.length} check${runningChecks.length > 1 ? 's' : ''} running`;
+    }
+
+    return "No active checks";
+  };
+
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center gap-1",
+        onClick && "cursor-pointer hover:opacity-80",
+        className
+      )}
+      onClick={onClick}
+      title={getTooltip()}
+    >
+      {getStatusIcon()}
+      {showLabel && (
+        <span className={cn(
+          "text-xs font-medium",
+          getStatusColor()
+        )}>
+          {getStatusLabel()}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/src/renderer/components/CheckStatusDetails.tsx
+++ b/src/renderer/components/CheckStatusDetails.tsx
@@ -1,0 +1,384 @@
+import React, { useState } from "react";
+import { 
+  CheckCircle2, 
+  XCircle, 
+  Loader2, 
+  Circle,
+  ChevronDown,
+  ChevronRight,
+  ExternalLink,
+  Clock,
+  AlertCircle,
+  RefreshCw
+} from "lucide-react";
+import { cn } from "../utils/cn";
+import { BranchCheckStatus, CheckRun, WorkflowRun } from "../services/github";
+import { formatDistanceToNow } from "date-fns";
+import { useUIStore } from "../stores/uiStore";
+
+interface CheckStatusDetailsProps {
+  status: BranchCheckStatus;
+  branchName: string;
+  onRefresh?: () => void;
+  isRefreshing?: boolean;
+}
+
+export const CheckStatusDetails: React.FC<CheckStatusDetailsProps> = ({
+  status,
+  branchName,
+  onRefresh,
+  isRefreshing = false,
+}) => {
+  const { theme } = useUIStore();
+  const [expandedChecks, setExpandedChecks] = useState<Set<string>>(new Set());
+
+  const toggleCheck = (checkId: string) => {
+    setExpandedChecks(prev => {
+      const next = new Set(prev);
+      if (next.has(checkId)) {
+        next.delete(checkId);
+      } else {
+        next.add(checkId);
+      }
+      return next;
+    });
+  };
+
+  const getStatusIcon = (checkStatus: string, conclusion: string | null) => {
+    if (checkStatus === "queued" || checkStatus === "in_progress") {
+      return <Loader2 className="w-4 h-4 text-yellow-500 animate-spin" />;
+    }
+    
+    switch (conclusion) {
+      case "success":
+        return <CheckCircle2 className="w-4 h-4 text-green-500" />;
+      case "failure":
+      case "timed_out":
+        return <XCircle className="w-4 h-4 text-red-500" />;
+      case "cancelled":
+        return <Circle className="w-4 h-4 text-gray-400" />;
+      case "skipped":
+      case "neutral":
+        return <Circle className="w-4 h-4 text-gray-400" />;
+      case "action_required":
+        return <AlertCircle className="w-4 h-4 text-orange-500" />;
+      default:
+        return <Circle className="w-4 h-4 text-gray-400" />;
+    }
+  };
+
+  const getStatusLabel = (checkStatus: string, conclusion: string | null) => {
+    if (checkStatus === "queued") return "Queued";
+    if (checkStatus === "in_progress") return "In Progress";
+    
+    switch (conclusion) {
+      case "success": return "Success";
+      case "failure": return "Failed";
+      case "timed_out": return "Timed Out";
+      case "cancelled": return "Cancelled";
+      case "skipped": return "Skipped";
+      case "neutral": return "Neutral";
+      case "action_required": return "Action Required";
+      default: return "Unknown";
+    }
+  };
+
+  const getStatusColor = (checkStatus: string, conclusion: string | null) => {
+    if (checkStatus === "queued" || checkStatus === "in_progress") {
+      return "text-yellow-600";
+    }
+    
+    switch (conclusion) {
+      case "success": return "text-green-600";
+      case "failure":
+      case "timed_out": return "text-red-600";
+      case "action_required": return "text-orange-600";
+      default: return "text-gray-600";
+    }
+  };
+
+  const allChecks = [
+    ...status.checkRuns.map(r => ({ ...r, type: 'check' as const })),
+    ...status.workflowRuns.map(r => ({ ...r, type: 'workflow' as const }))
+  ];
+
+  // Group checks by status
+  const groupedChecks = {
+    running: allChecks.filter(c => c.status === "in_progress" || c.status === "queued"),
+    failed: allChecks.filter(c => c.conclusion === "failure" || c.conclusion === "timed_out" || c.conclusion === "action_required"),
+    passed: allChecks.filter(c => c.conclusion === "success"),
+    other: allChecks.filter(c => 
+      c.status === "completed" && 
+      c.conclusion !== "success" && 
+      c.conclusion !== "failure" && 
+      c.conclusion !== "timed_out" && 
+      c.conclusion !== "action_required"
+    ),
+  };
+
+  const hasChecks = allChecks.length > 0;
+
+  return (
+    <div className={cn(
+      "rounded-lg border p-4",
+      theme === "dark" 
+        ? "bg-gray-800 border-gray-700" 
+        : "bg-white border-gray-200"
+    )}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-semibold">
+            GitHub Actions Status
+          </h3>
+          <span className={cn(
+            "text-xs px-2 py-0.5 rounded-full",
+            status.overallStatus === "success" && "bg-green-100 text-green-700",
+            status.overallStatus === "failure" && "bg-red-100 text-red-700",
+            status.overallStatus === "pending" && "bg-yellow-100 text-yellow-700",
+            status.overallStatus === "none" && "bg-gray-100 text-gray-700",
+            theme === "dark" && status.overallStatus === "success" && "bg-green-900/30 text-green-400",
+            theme === "dark" && status.overallStatus === "failure" && "bg-red-900/30 text-red-400",
+            theme === "dark" && status.overallStatus === "pending" && "bg-yellow-900/30 text-yellow-400",
+            theme === "dark" && status.overallStatus === "none" && "bg-gray-700 text-gray-400"
+          )}>
+            {status.overallStatus === "success" && "All checks passed"}
+            {status.overallStatus === "failure" && "Some checks failed"}
+            {status.overallStatus === "pending" && "Checks running"}
+            {status.overallStatus === "none" && "No checks"}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {status.lastUpdated && (
+            <span className={cn(
+              "text-xs",
+              theme === "dark" ? "text-gray-400" : "text-gray-500"
+            )}>
+              Updated {formatDistanceToNow(new Date(status.lastUpdated), { addSuffix: true })}
+            </span>
+          )}
+          {onRefresh && (
+            <button
+              onClick={onRefresh}
+              disabled={isRefreshing}
+              className={cn(
+                "p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors",
+                isRefreshing && "opacity-50 cursor-not-allowed"
+              )}
+              title="Refresh check status"
+            >
+              <RefreshCw className={cn(
+                "w-4 h-4",
+                theme === "dark" ? "text-gray-400" : "text-gray-600",
+                isRefreshing && "animate-spin"
+              )} />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* No checks message */}
+      {!hasChecks && (
+        <div className={cn(
+          "text-sm py-8 text-center",
+          theme === "dark" ? "text-gray-400" : "text-gray-500"
+        )}>
+          No GitHub Actions configured for this branch
+        </div>
+      )}
+
+      {/* Check groups */}
+      {hasChecks && (
+        <div className="space-y-3">
+          {/* Running checks */}
+          {groupedChecks.running.length > 0 && (
+            <div>
+              <h4 className={cn(
+                "text-xs font-medium mb-2",
+                theme === "dark" ? "text-yellow-400" : "text-yellow-600"
+              )}>
+                Running ({groupedChecks.running.length})
+              </h4>
+              <div className="space-y-1">
+                {groupedChecks.running.map((check) => (
+                  <CheckItem 
+                    key={`${check.type}-${check.id}`}
+                    check={check}
+                    isExpanded={expandedChecks.has(`${check.type}-${check.id}`)}
+                    onToggle={() => toggleCheck(`${check.type}-${check.id}`)}
+                    theme={theme}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Failed checks */}
+          {groupedChecks.failed.length > 0 && (
+            <div>
+              <h4 className={cn(
+                "text-xs font-medium mb-2",
+                theme === "dark" ? "text-red-400" : "text-red-600"
+              )}>
+                Failed ({groupedChecks.failed.length})
+              </h4>
+              <div className="space-y-1">
+                {groupedChecks.failed.map((check) => (
+                  <CheckItem 
+                    key={`${check.type}-${check.id}`}
+                    check={check}
+                    isExpanded={expandedChecks.has(`${check.type}-${check.id}`)}
+                    onToggle={() => toggleCheck(`${check.type}-${check.id}`)}
+                    theme={theme}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Passed checks */}
+          {groupedChecks.passed.length > 0 && (
+            <div>
+              <h4 className={cn(
+                "text-xs font-medium mb-2",
+                theme === "dark" ? "text-green-400" : "text-green-600"
+              )}>
+                Passed ({groupedChecks.passed.length})
+              </h4>
+              <div className="space-y-1">
+                {groupedChecks.passed.map((check) => (
+                  <CheckItem 
+                    key={`${check.type}-${check.id}`}
+                    check={check}
+                    isExpanded={expandedChecks.has(`${check.type}-${check.id}`)}
+                    onToggle={() => toggleCheck(`${check.type}-${check.id}`)}
+                    theme={theme}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Other checks (skipped, cancelled, etc.) */}
+          {groupedChecks.other.length > 0 && (
+            <div>
+              <h4 className={cn(
+                "text-xs font-medium mb-2",
+                theme === "dark" ? "text-gray-400" : "text-gray-600"
+              )}>
+                Other ({groupedChecks.other.length})
+              </h4>
+              <div className="space-y-1">
+                {groupedChecks.other.map((check) => (
+                  <CheckItem 
+                    key={`${check.type}-${check.id}`}
+                    check={check}
+                    isExpanded={expandedChecks.has(`${check.type}-${check.id}`)}
+                    onToggle={() => toggleCheck(`${check.type}-${check.id}`)}
+                    theme={theme}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// Individual check item component
+interface CheckItemProps {
+  check: (CheckRun | WorkflowRun) & { type: 'check' | 'workflow' };
+  isExpanded: boolean;
+  onToggle: () => void;
+  theme: string;
+}
+
+const CheckItem: React.FC<CheckItemProps> = ({ check, isExpanded, onToggle, theme }) => {
+  const getStatusIcon = (checkStatus: string, conclusion: string | null) => {
+    if (checkStatus === "queued" || checkStatus === "in_progress") {
+      return <Loader2 className="w-4 h-4 text-yellow-500 animate-spin" />;
+    }
+    
+    switch (conclusion) {
+      case "success":
+        return <CheckCircle2 className="w-4 h-4 text-green-500" />;
+      case "failure":
+      case "timed_out":
+        return <XCircle className="w-4 h-4 text-red-500" />;
+      case "cancelled":
+        return <Circle className="w-4 h-4 text-gray-400" />;
+      case "skipped":
+      case "neutral":
+        return <Circle className="w-4 h-4 text-gray-400" />;
+      case "action_required":
+        return <AlertCircle className="w-4 h-4 text-orange-500" />;
+      default:
+        return <Circle className="w-4 h-4 text-gray-400" />;
+    }
+  };
+
+  return (
+    <div className={cn(
+      "rounded border",
+      theme === "dark" 
+        ? "bg-gray-900 border-gray-700" 
+        : "bg-gray-50 border-gray-200"
+    )}>
+      <div 
+        className="flex items-center gap-2 p-2 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800"
+        onClick={onToggle}
+      >
+        <button className="p-0.5">
+          {isExpanded ? (
+            <ChevronDown className="w-3 h-3" />
+          ) : (
+            <ChevronRight className="w-3 h-3" />
+          )}
+        </button>
+        {getStatusIcon(check.status, check.conclusion)}
+        <span className="text-xs font-medium flex-1 truncate">
+          {check.name}
+        </span>
+        <a
+          href={check.html_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          className={cn(
+            "p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700",
+            theme === "dark" ? "text-gray-400" : "text-gray-600"
+          )}
+          title="View on GitHub"
+        >
+          <ExternalLink className="w-3 h-3" />
+        </a>
+      </div>
+
+      {isExpanded && (
+        <div className={cn(
+          "px-8 pb-2 text-xs space-y-1",
+          theme === "dark" ? "text-gray-400" : "text-gray-600"
+        )}>
+          {check.type === 'workflow' && (
+            <>
+              <div>Event: {(check as WorkflowRun).event}</div>
+              <div>Run: #{(check as WorkflowRun).run_number}</div>
+            </>
+          )}
+          {'started_at' in check && check.started_at && (
+            <div>Started: {formatDistanceToNow(new Date(check.started_at), { addSuffix: true })}</div>
+          )}
+          {'completed_at' in check && check.completed_at && (
+            <div>Completed: {formatDistanceToNow(new Date(check.completed_at), { addSuffix: true })}</div>
+          )}
+          {check.app && (
+            <div>App: {check.app.name}</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
Add GitHub Actions check status display to branches for immediate visibility of CI/CD pipeline health directly in the UI (solves #7).

---
<a href="https://cursor.com/background-agent?bcId=bc-79ccbc27-83c4-4865-9759-303e99ba0e62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-79ccbc27-83c4-4865-9759-303e99ba0e62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

