### PR TITLE
Persist PR list filters

### DIFF
--- a/src/renderer/types/prList.ts
+++ b/src/renderer/types/prList.ts
@@ -2,6 +2,8 @@ import type { PullRequest } from "../services/github";
 
 export type SortByType = "updated" | "created";
 
+export type PRStatusFilter = "open" | "draft" | "merged" | "closed";
+
 export interface PRWithMetadata {
   pr: PullRequest;
   agent: string;


### PR DESCRIPTION
## Summary
- persist PR list sort, author, and status selections in the UI store so they survive navigation
- update the PR list view to consume the stored filters and share status filter typing across modules

## Testing
- CI=1 npm run build:renderer -- --logLevel warn

------
https://chatgpt.com/codex/tasks/task_e_68d5d09cac848321a53930c40a74bad7