### PR TITLE
Persist PR filters between list and detail views

### DIFF
--- a/src/renderer/stores/uiStore.ts
+++ b/src/renderer/stores/uiStore.ts
@@ -1,6 +1,8 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
+import type { PRStatusFilter, SortByType } from "../types/prList";
+
 interface UIState {
   sidebarOpen: boolean;
   sidebarWidth: number;
@@ -13,6 +15,12 @@ interface UIState {
   showWhitespace: boolean;
   wordWrap: boolean;
   theme: "light" | "dark";
+
+  prListFilters: {
+    sortBy: SortByType;
+    selectedAuthors: Set<string>;
+    selectedStatuses: Set<PRStatusFilter>;
+  };
 
   // PR navigation state for sidebar
   prNavigationState: {
@@ -36,6 +44,14 @@ interface UIState {
   clearSelection: () => void;
   setActiveView: (view: "list" | "detail") => void;
   setPRNavigationState: (state: UIState["prNavigationState"]) => void;
+  setPRListSortBy: (sortBy: SortByType) => void;
+  setPRListSelectedAuthors: (
+    updater: (current: Set<string>) => Set<string>,
+  ) => void;
+  setPRListSelectedStatuses: (
+    updater: (current: Set<PRStatusFilter>) => Set<PRStatusFilter>,
+  ) => void;
+  resetPRListFilters: () => void;
 }
 
 export const useUIStore = create<UIState>()(
@@ -52,6 +68,11 @@ export const useUIStore = create<UIState>()(
       showWhitespace: false,
       wordWrap: false,
       theme: "dark",
+      prListFilters: {
+        sortBy: "updated",
+        selectedAuthors: new Set(),
+        selectedStatuses: new Set(),
+      },
       prNavigationState: null,
 
       toggleSidebar: () =>
@@ -94,6 +115,40 @@ export const useUIStore = create<UIState>()(
       clearSelection: () => set({ selectedPRs: new Set() }),
       setActiveView: (view) => set({ activeView: view }),
       setPRNavigationState: (state) => set({ prNavigationState: state }),
+      setPRListSortBy: (sortBy) =>
+        set((state) => ({
+          prListFilters: {
+            ...state.prListFilters,
+            sortBy,
+          },
+        })),
+      setPRListSelectedAuthors: (updater) =>
+        set((state) => ({
+          prListFilters: {
+            ...state.prListFilters,
+            selectedAuthors: updater(
+              new Set(state.prListFilters.selectedAuthors),
+            ),
+          },
+        })),
+      setPRListSelectedStatuses: (updater) =>
+        set((state) => ({
+          prListFilters: {
+            ...state.prListFilters,
+            selectedStatuses: updater(
+              new Set(state.prListFilters.selectedStatuses),
+            ),
+          },
+        })),
+      resetPRListFilters: () =>
+        set((state) => ({
+          prListFilters: {
+            ...state.prListFilters,
+            sortBy: "updated",
+            selectedAuthors: new Set(),
+            selectedStatuses: new Set(),
+          },
+        })),
     }),
     {
       name: "ui-storage",

--- a/src/renderer/types/prList.ts
+++ b/src/renderer/types/prList.ts
@@ -1,6 +1,7 @@
 import type { PullRequest } from "../services/github";
 
 export type SortByType = "updated" | "created";
+export type PRStatusFilter = "open" | "draft" | "merged" | "closed";
 
 export interface PRWithMetadata {
   pr: PullRequest;

--- a/src/renderer/views/PRListView.tsx
+++ b/src/renderer/views/PRListView.tsx
@@ -9,20 +9,22 @@ import { cn } from "../utils/cn";
 import WelcomeView from "./WelcomeView";
 import { PullRequest } from "../services/github";
 import { PRTreeView } from "../components/PRTreeView";
-import type { SortByType, PRWithMetadata } from "../types/prList";
-
-type StatusType = "open" | "draft" | "merged" | "closed";
+import type {
+  PRStatusFilter,
+  PRWithMetadata,
+  SortByType,
+} from "../types/prList";
 
 const sortOptions: DropdownOption<SortByType>[] = [
   { value: "updated", label: "Recently updated" },
   { value: "created", label: "Recently created" },
 ];
 
-const statusOptions = [
-  { value: "open" as StatusType, label: "Open" },
-  { value: "draft" as StatusType, label: "Draft" },
-  { value: "merged" as StatusType, label: "Merged" },
-  { value: "closed" as StatusType, label: "Closed" },
+const statusOptions: { value: PRStatusFilter; label: string }[] = [
+  { value: "open", label: "Open" },
+  { value: "draft", label: "Draft" },
+  { value: "merged", label: "Merged" },
+  { value: "closed", label: "Closed" },
 ];
 
 export default function PRListView() {
@@ -36,13 +38,20 @@ export default function PRListView() {
     currentRepoKey,
     pendingRepoKey,
   } = usePRStore();
-  const { selectedPRs, selectPR, deselectPR, clearSelection, theme } =
-    useUIStore();
-  const [sortBy, setSortBy] = useState<SortByType>("updated");
-  const [selectedAuthors, setSelectedAuthors] = useState<Set<string>>(new Set());
+  const {
+    selectedPRs,
+    selectPR,
+    deselectPR,
+    clearSelection,
+    theme,
+    prListFilters,
+    setPRListSortBy,
+    setPRListSelectedAuthors,
+    setPRListSelectedStatuses,
+  } = useUIStore();
+  const { sortBy, selectedAuthors, selectedStatuses } = prListFilters;
   const [showAuthorDropdown, setShowAuthorDropdown] = useState(false);
   const authorDropdownRef = useRef<HTMLDivElement>(null);
-  const [selectedStatuses, setSelectedStatuses] = useState<Set<StatusType>>(new Set());
   const [showStatusDropdown, setShowStatusDropdown] = useState(false);
   const statusDropdownRef = useRef<HTMLDivElement>(null);
 
@@ -158,19 +167,19 @@ export default function PRListView() {
     return Array.from(authorMap.values());
   }, [pullRequests]);
 
-  const handleAuthorToggle = useCallback((authorLogin: string) => {
-    setSelectedAuthors(prev => {
-      const newSet = new Set(prev);
-      if (authorLogin === "all") {
-        // Toggle between all selected and none selected
-        if (newSet.size === 0 || !newSet.has("all")) {
-          // Select all
-          return new Set(["all", ...authors.map(a => a.login)]);
-        } else {
-          // Deselect all
+  const handleAuthorToggle = useCallback(
+    (authorLogin: string) => {
+      setPRListSelectedAuthors((prev) => {
+        if (authorLogin === "all") {
+          // Toggle between all selected and none selected
+          if (prev.size === 0 || !prev.has("all")) {
+            return new Set(["all", ...authors.map((a) => a.login)]);
+          }
           return new Set();
         }
-      } else {
+
+        const newSet = new Set(prev);
+
         // Toggle individual author
         if (newSet.has(authorLogin)) {
           newSet.delete(authorLogin);
@@ -178,48 +187,48 @@ export default function PRListView() {
         } else {
           newSet.add(authorLogin);
           // Check if all authors are now selected
-          if (authors.every(a => newSet.has(a.login))) {
+          if (authors.every((a) => newSet.has(a.login))) {
             newSet.add("all");
           }
         }
-      }
-      return newSet;
-    });
-  }, [authors]);
+
+        return newSet;
+      });
+    },
+    [authors, setPRListSelectedAuthors],
+  );
 
   // Helper function to get PR status
-  const getPRStatus = useCallback((pr: PullRequest): StatusType => {
+  const getPRStatus = useCallback((pr: PullRequest): PRStatusFilter => {
     if (pr.draft) return "draft";
     if (pr.merged) return "merged";
     if (pr.state === "closed") return "closed";
     return "open";
   }, []);
 
-  const handleStatusToggle = useCallback((status: StatusType | "all") => {
-    setSelectedStatuses(prev => {
-      if (status === "all") {
-        // Toggle between all selected and none selected
-        if (prev.size === 0 || prev.size < statusOptions.length) {
-          // Select all
-          return new Set(statusOptions.map(s => s.value));
-        } else {
-          // Deselect all (which means show all in our logic)
+  const handleStatusToggle = useCallback(
+    (status: PRStatusFilter | "all") => {
+      setPRListSelectedStatuses((prev) => {
+        if (status === "all") {
+          // Toggle between all selected and none selected
+          if (prev.size === 0 || prev.size < statusOptions.length) {
+            return new Set(statusOptions.map((s) => s.value));
+          }
           return new Set();
         }
-      } else {
-        // Toggle individual status - create a new Set to ensure React detects the change
-        const prevArray = Array.from(prev);
-        if (prev.has(status)) {
-          // Remove the status
-          const newArray = prevArray.filter(s => s !== status);
-          return new Set(newArray);
+
+        const updated = new Set(prev);
+        if (updated.has(status)) {
+          updated.delete(status);
         } else {
-          // Add the status
-          return new Set([...prevArray, status]);
+          updated.add(status);
         }
-      }
-    });
-  }, []);
+
+        return updated;
+      });
+    },
+    [setPRListSelectedStatuses],
+  );
 
   // Extract common prefix from PR title for sub-grouping
   const getTitlePrefix = useCallback((title: string): string => {
@@ -491,7 +500,7 @@ export default function PRListView() {
               <Dropdown<SortByType>
                 options={sortOptions}
                 value={sortBy}
-                onChange={setSortBy}
+                onChange={setPRListSortBy}
                 labelPrefix="Sort by: "
               />
 


### PR DESCRIPTION
## Summary
- add persistent PR list filter state to the UI store so selections survive navigation
- update the PR list view to read and write filter choices from the store and share a PR status filter type

## Testing
- CI=1 npm run build:renderer

------
https://chatgpt.com/codex/tasks/task_e_68d5d09cac848321a53930c40a74bad7