### PR TITLE
Persist pull request list filters

### DIFF
--- a/src/renderer/stores/uiStore.ts
+++ b/src/renderer/stores/uiStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import type { SortByType, PRStatusType } from "../types/prList";
 
 interface UIState {
   sidebarOpen: boolean;
@@ -13,6 +14,10 @@ interface UIState {
   showWhitespace: boolean;
   wordWrap: boolean;
   theme: "light" | "dark";
+
+  prListSortBy: SortByType;
+  prListSelectedAuthors: Set<string>;
+  prListSelectedStatuses: Set<PRStatusType>;
 
   // PR navigation state for sidebar
   prNavigationState: {
@@ -36,6 +41,14 @@ interface UIState {
   clearSelection: () => void;
   setActiveView: (view: "list" | "detail") => void;
   setPRNavigationState: (state: UIState["prNavigationState"]) => void;
+  setPRListSortBy: (sortBy: SortByType) => void;
+  setPRListSelectedAuthors: (
+    updater: (prev: Set<string>) => Set<string>,
+  ) => void;
+  setPRListSelectedStatuses: (
+    updater: (prev: Set<PRStatusType>) => Set<PRStatusType>,
+  ) => void;
+  resetPRListFilters: () => void;
 }
 
 export const useUIStore = create<UIState>()(
@@ -52,6 +65,9 @@ export const useUIStore = create<UIState>()(
       showWhitespace: false,
       wordWrap: false,
       theme: "dark",
+      prListSortBy: "updated",
+      prListSelectedAuthors: new Set(),
+      prListSelectedStatuses: new Set(),
       prNavigationState: null,
 
       toggleSidebar: () =>
@@ -94,6 +110,21 @@ export const useUIStore = create<UIState>()(
       clearSelection: () => set({ selectedPRs: new Set() }),
       setActiveView: (view) => set({ activeView: view }),
       setPRNavigationState: (state) => set({ prNavigationState: state }),
+      setPRListSortBy: (sortBy) => set({ prListSortBy: sortBy }),
+      setPRListSelectedAuthors: (updater) =>
+        set((state) => ({
+          prListSelectedAuthors: updater(state.prListSelectedAuthors),
+        })),
+      setPRListSelectedStatuses: (updater) =>
+        set((state) => ({
+          prListSelectedStatuses: updater(state.prListSelectedStatuses),
+        })),
+      resetPRListFilters: () =>
+        set({
+          prListSortBy: "updated",
+          prListSelectedAuthors: new Set(),
+          prListSelectedStatuses: new Set(),
+        }),
     }),
     {
       name: "ui-storage",

--- a/src/renderer/types/prList.ts
+++ b/src/renderer/types/prList.ts
@@ -1,6 +1,7 @@
 import type { PullRequest } from "../services/github";
 
 export type SortByType = "updated" | "created";
+export type PRStatusType = "open" | "draft" | "merged" | "closed";
 
 export interface PRWithMetadata {
   pr: PullRequest;


### PR DESCRIPTION
## Summary
- add a shared PR status type definition for reuse across the renderer
- extend the UI store with PR list filter state and mutators
- read and update filter state from the store in the PR list view so selections persist when navigating away

## Testing
- CI=1 npm run build:renderer

------
https://chatgpt.com/codex/tasks/task_e_68d5d09cac848321a53930c40a74bad7