### PR TITLE
Add pre-saved team author filters

### DIFF
--- a/src/renderer/stores/authorTeamStore.ts
+++ b/src/renderer/stores/authorTeamStore.ts
@@ -1,0 +1,72 @@
+import { create } from "zustand";
+import { nanoid } from "nanoid";
+
+export interface AuthorTeam {
+  id: string;
+  name: string;
+  members: string[]; // GitHub logins
+  createdAt: string;
+}
+
+interface AuthorTeamState {
+  teams: AuthorTeam[];
+  addTeam: (name: string, members: string[]) => void;
+  updateTeam: (id: string, data: Partial<Omit<AuthorTeam, "id" | "createdAt">>) => void;
+  deleteTeam: (id: string) => void;
+}
+
+const STORAGE_KEY = "authorTeams";
+
+function loadTeams(): AuthorTeam[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) return parsed as AuthorTeam[];
+    }
+  } catch (err) {
+    console.error("Failed to load author teams:", err);
+  }
+  return [];
+}
+
+function saveTeams(teams: AuthorTeam[]) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(teams));
+  } catch (err) {
+    console.error("Failed to save author teams:", err);
+  }
+}
+
+export const useAuthorTeamStore = create<AuthorTeamState>((set, get) => ({
+  teams: loadTeams(),
+  addTeam: (name, members) => {
+    const newTeam: AuthorTeam = {
+      id: nanoid(),
+      name,
+      members: Array.from(new Set(members)),
+      createdAt: new Date().toISOString(),
+    };
+    set((state) => {
+      const updated = [...state.teams, newTeam];
+      saveTeams(updated);
+      return { teams: updated };
+    });
+  },
+  updateTeam: (id, data) => {
+    set((state) => {
+      const updated = state.teams.map((team) =>
+        team.id === id ? { ...team, ...data } : team,
+      );
+      saveTeams(updated);
+      return { teams: updated };
+    });
+  },
+  deleteTeam: (id) => {
+    set((state) => {
+      const updated = state.teams.filter((team) => team.id !== id);
+      saveTeams(updated);
+      return { teams: updated };
+    });
+  },
+}));

--- a/src/renderer/views/PRListView.tsx
+++ b/src/renderer/views/PRListView.tsx
@@ -13,6 +13,7 @@ import WelcomeView from "./WelcomeView";
 import { GitHubAPI, PullRequest } from "../services/github";
 import { PRTreeView } from "../components/PRTreeView";
 import type { SortByType, PRWithMetadata } from "../types/prList";
+import { useAuthorTeamStore } from "../stores/authorTeamStore";
 
 type StatusType = PRStatusType; // Use the centralized type
 
@@ -50,6 +51,7 @@ export default function PRListView() {
     setPRListFilters,
   } = useUIStore();
   const { token } = useAuthStore();
+  const { teams } = useAuthorTeamStore();
   const [showAuthorDropdown, setShowAuthorDropdown] = useState(false);
   const authorDropdownRef = useRef<HTMLDivElement>(null);
   const [showStatusDropdown, setShowStatusDropdown] = useState(false);
@@ -221,6 +223,26 @@ export default function PRListView() {
           ...prev,
           selectedAuthors: Array.from(newSet),
         };
+      });
+    },
+    [authors, setPRListFilters],
+  );
+
+  const handleTeamToggle = useCallback(
+    (teamMembers: string[]) => {
+      setPRListFilters(prev => {
+        const newSet = new Set(prev.selectedAuthors);
+        const allSelected = teamMembers.every(m => newSet.has(m));
+        if (allSelected) {
+          teamMembers.forEach(m => newSet.delete(m));
+          newSet.delete("all");
+        } else {
+          teamMembers.forEach(m => newSet.add(m));
+          if (authors.every(a => newSet.has(a.login))) {
+            newSet.add("all");
+          }
+        }
+        return { ...prev, selectedAuthors: Array.from(newSet) };
       });
     },
     [authors, setPRListFilters],
@@ -851,6 +873,39 @@ export default function PRListView() {
                         theme === "dark" ? "border-gray-700" : "border-gray-200"
                       )} />
 
+                      {/* Individual authors */}
+                      {/* Teams section */}
+                      {teams.length > 0 && (
+                        <>
+                          <div className={cn(
+                            "my-1 border-t",
+                            theme === "dark" ? "border-gray-700" : "border-gray-200",
+                          )} />
+                          <div className="px-2 py-1 text-xs font-semibold opacity-70">Teams</div>
+                          {teams.map(team => {
+                            const allSelected = team.members.every(m => selectedAuthors.has(m));
+                            return (
+                              <label
+                                key={team.id}
+                                className={cn(
+                                  "flex items-center space-x-2 p-2 rounded cursor-pointer",
+                                  theme === "dark" ? "hover:bg-gray-700" : "hover:bg-gray-50",
+                                )}
+                              >
+                                <input
+                                  type="checkbox"
+                                  checked={allSelected}
+                                  onChange={() => handleTeamToggle(team.members)}
+                                  className="rounded"
+                                />
+                                <span className="text-sm font-medium truncate">
+                                  {team.name} ({team.members.length})
+                                </span>
+                              </label>
+                            );
+                          })}
+                        </>
+                      )}
                       {/* Individual authors */}
                       {authors.map(author => (
                         <label


### PR DESCRIPTION
Add initial support for author teams in the author filter dropdown to allow quick selection of pre-defined author groups.

---
<a href="https://cursor.com/background-agent?bcId=bc-0dd6a457-12fd-44c3-bbef-5391f7be7340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0dd6a457-12fd-44c3-bbef-5391f7be7340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



Relates to #32