### PR TITLE
Fix sidebar hide functionality

### DIFF
--- a/src/renderer/utils/keyboard.ts
+++ b/src/renderer/utils/keyboard.ts
@@ -85,7 +85,9 @@ export function setupKeyboardShortcuts() {
     }
   };
 
-  document.addEventListener("keydown", handleKeyDown);
+  // Use the capture phase so we receive the event even if a child component
+  // stops propagation (e.g. Monaco editor or content-editable elements).
+  window.addEventListener("keydown", handleKeyDown, true);
 
   // Listen to IPC events from the main process menu
   window.electron.on("toggle-sidebar", () => {
@@ -105,6 +107,6 @@ export function setupKeyboardShortcuts() {
   });
 
   return () => {
-    document.removeEventListener("keydown", handleKeyDown);
+    window.removeEventListener("keydown", handleKeyDown, true);
   };
 }


### PR DESCRIPTION
Fix sidebar toggle shortcut not working when focus is inside components like code editors.

The keyboard shortcut (Cmd/Ctrl + B) and corresponding View menu option to toggle the sidebar previously failed to work when focus was within certain components, such as code editors, because these components would intercept and stop propagation of the `keydown` event. This change adjusts the `keydown` event listener to `window` in the capture phase, ensuring the event is received and processed before any child components can intercept it.

---
<a href="https://cursor.com/background-agent?bcId=bc-338b502e-cfc8-4129-8ce4-652051a1b316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-338b502e-cfc8-4129-8ce4-652051a1b316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

