### PR TITLE
Fix sidebar hide functionality

### DIFF
--- a/src/renderer/utils/keyboard.ts
+++ b/src/renderer/utils/keyboard.ts
@@ -1,12 +1,7 @@
 import { useUIStore } from "../stores/uiStore";
 
 export function setupKeyboardShortcuts() {
-  if (!window.electron) {
-    console.warn(
-      "window.electron not available, skipping keyboard shortcuts setup",
-    );
-    return () => {};
-  }
+  const isElectron = Boolean(window.electron);
 
   const handleKeyDown = (e: KeyboardEvent) => {
     const {
@@ -20,29 +15,41 @@ export function setupKeyboardShortcuts() {
     if (e.metaKey || e.ctrlKey) {
       // Toggle sidebar (Cmd/Ctrl + B)
       if (e.key === "b" && !e.shiftKey) {
-        e.preventDefault();
-        toggleSidebar();
+        // In Electron, the menu accelerator handles this and sends an IPC event.
+        if (!isElectron) {
+          e.preventDefault();
+          toggleSidebar();
+        }
         return;
       }
 
       // Toggle right panel (Cmd/Ctrl + Shift + B)
       if (e.key === "b" && e.shiftKey) {
-        e.preventDefault();
-        toggleRightPanel();
+        // In Electron, the menu accelerator handles this and sends an IPC event.
+        if (!isElectron) {
+          e.preventDefault();
+          toggleRightPanel();
+        }
         return;
       }
 
       // Open command palette (Cmd/Ctrl + Shift + P)
       if (e.key === "p" && e.shiftKey) {
-        e.preventDefault();
-        toggleCommandPalette();
+        // In Electron, the menu accelerator handles this and sends an IPC event.
+        if (!isElectron) {
+          e.preventDefault();
+          toggleCommandPalette();
+        }
         return;
       }
 
       // Show keyboard shortcuts (Cmd/Ctrl + /)
       if (e.key === "/") {
-        e.preventDefault();
-        toggleKeyboardShortcuts();
+        // In Electron, the menu accelerator handles this and sends an IPC event.
+        if (!isElectron) {
+          e.preventDefault();
+          toggleKeyboardShortcuts();
+        }
         return;
       }
 


### PR DESCRIPTION
Centralize keyboard shortcut handling to Electron's menu accelerators by disabling renderer-side handling when in Electron, fixing the broken sidebar toggle and other shortcuts.

---
<a href="https://cursor.com/background-agent?bcId=bc-a78ee57a-724b-4f57-ba04-faf7b418654d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a78ee57a-724b-4f57-ba04-faf7b418654d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

