### PR TITLE
Automate electron app distribution via github releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "electron": "electron .",
     "start": "npm run build && npm run electron",
     "dist": "npm run build && electron-builder",
+    "changeset": "changeset",
+    "version-packages": "changeset version",
+    "release": "npm run dist",
     "postinstall": "electron-rebuild",
     "rebuild": "electron-rebuild"
   },
@@ -41,10 +44,12 @@
     "electron-builder": "^24.9.1",
     "electron-devtools-installer": "^4.0.0",
     "electron-rebuild": "^3.2.9",
+    "electron-notarize": "^2.2.1",
     "eslint": "^8.56.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "postcss": "^8.5.6",
+    "@changesets/cli": "^2.27.8",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.3.3",
     "vite": "^5.0.11",
@@ -63,6 +68,8 @@
     "date-fns": "^3.2.0",
     "dotenv": "^17.2.2",
     "electron-store": "^8.1.0",
+    "electron-updater": "^6.3.9",
+    "electron-log": "^5.2.0",
     "framer-motion": "^10.18.0",
     "lucide-react": "^0.312.0",
     "monaco-editor": "^0.45.0",
@@ -83,21 +90,62 @@
   "build": {
     "appId": "com.bottleneck.app",
     "productName": "Bottleneck",
+    "asar": true,
     "directories": {
-      "output": "release"
+      "output": "release",
+      "buildResources": "build"
     },
     "files": [
       "dist/**/*",
       "node_modules/**/*"
     ],
+    "publish": [
+      {
+        "provider": "github",
+        "releaseType": "draft"
+      }
+    ],
+    "generateReleaseNotes": true,
     "mac": {
-      "category": "public.app-category.developer-tools"
+      "category": "public.app-category.developer-tools",
+      "hardenedRuntime": true,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.inherit.plist",
+      "gatekeeperAssess": false,
+      "target": [
+        "dmg",
+        "zip"
+      ],
+      "artifactName": "${productName}-${version}-mac-${arch}.${ext}",
+      "universalApp": true
     },
-    "linux": {
-      "target": "AppImage"
+    "dmg": {
+      "artifactName": "${productName}-${version}.dmg"
     },
     "win": {
-      "target": "nsis"
-    }
+      "target": [
+        "nsis",
+        "msi",
+        "zip"
+      ],
+      "artifactName": "${productName}-${version}-win-${arch}.${ext}"
+    },
+    "nsis": {
+      "oneClick": true,
+      "perMachine": false,
+      "allowToChangeInstallationDirectory": false
+    },
+    "linux": {
+      "category": "Development",
+      "target": [
+        "AppImage",
+        "deb",
+        "rpm",
+        "snap",
+        "tar.gz"
+      ],
+      "artifactName": "${productName}-${version}-linux-${arch}.${ext}"
+    },
+    "afterSign": "scripts/notarize.js"
   }
 }


### PR DESCRIPTION
Configure `electron-builder` for multi-platform GitHub Releases, notarization, and auto-update support to enable automated app distribution.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce45ddbd-1603-4d16-be4b-633e05256701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ce45ddbd-1603-4d16-be4b-633e05256701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

