### PR TITLE
Reduce macOS build output size

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ npm run build
 npm run dist
 ```
 
+By default the macOS build now targets only the architecture of the machine running the command, which keeps the generated DMG compact. If you need installers for both Apple Silicon and Intel, run `npm run dist -- --arm64` and `npm run dist -- --x64` separately (or pass `--universal` when you truly need a combined binary).
+
 ## Development
 
 ### Project Structure

--- a/package.json
+++ b/package.json
@@ -103,13 +103,9 @@
     "mac": {
       "icon": "icon.icns",
       "category": "public.app-category.developer-tools",
-      "target": {
-        "target": "default",
-        "arch": [
-          "arm64",
-          "x64"
-        ]
-      }
+      "target": [
+        "dmg"
+      ]
     },
     "linux": {
       "icon": "1024.png",


### PR DESCRIPTION
## Summary
- stop bundling both Intel and Apple Silicon binaries in the default macOS build to shrink the DMG
- document how to generate installers for each architecture or a universal build when needed

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e5b295e634832198fd3d4b5fb5c641