### PR TITLE
Update icon updater for 80% shrink

### DIFF
--- a/generate-icons.sh
+++ b/generate-icons.sh
@@ -17,20 +17,28 @@ fi
 
 echo "Creating rounded corner icons from $INPUT..."
 
-# Function to create rounded corners
+# Function to create rounded corners with 80% shrink for Electron dock icon
 create_rounded() {
     local input="$1"
     local output="$2"
     local size="$3"
-    local radius=$((size / 8))  # 12.5% radius for nice rounded corners
     
+    # Calculate 80% of the target size for the actual icon content
+    local content_size=$(awk "BEGIN {print int($size * 0.8)}")
+    local radius=$((content_size / 8))  # 12.5% radius for nice rounded corners
+    
+    # Calculate offset to center the 80% sized content
+    local offset=$(awk "BEGIN {print int(($size - $content_size) / 2)}")
+    
+    # Create the icon at 80% size with rounded corners, then composite onto full-size transparent canvas
     magick "$input" \
-        -resize "${size}x${size}" \
+        -resize "${content_size}x${content_size}" \
         \( +clone -alpha extract \
            -draw "fill black polygon 0,0 0,$radius $radius,0 fill white circle $radius,$radius $radius,0" \
            \( +clone -flip \) -compose Multiply -composite \
            \( +clone -flop \) -compose Multiply -composite \
         \) -alpha off -compose CopyOpacity -composite \
+        -background none -gravity center -extent "${size}x${size}" \
         "$output"
 }
 


### PR DESCRIPTION
Update the icon generation script to shrink Electron dock icons to 80% of their canvas size, preventing them from appearing too large on macOS.

This addresses a common issue with Electron apps where macOS dock icons are rendered at a larger visual size than intended. By shrinking the icon content to 80% and centering it with transparent padding, the icon will display at the appropriate visual size in the macOS dock.

---
<a href="https://cursor.com/background-agent?bcId=bc-1bf96b80-ec5e-47aa-a580-ed48806c1e33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1bf96b80-ec5e-47aa-a580-ed48806c1e33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

