### PR TITLE
Fix dev mode not working

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -118,8 +118,9 @@ function createWindow() {
   // Load the app
   const beforeLoad = Date.now();
   if (isDev) {
-    perfLog("Loading dev server URL");
-    mainWindow.loadURL("http://localhost:3000");
+    const devServerUrl = process.env.VITE_DEV_SERVER_URL || "http://localhost:3000";
+    perfLog("Loading dev server URL: " + devServerUrl);
+    mainWindow.loadURL(devServerUrl);
     perfLog("Dev URL loaded", beforeLoad);
     mainWindow.webContents.openDevTools();
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
   },
   server: {
     port: 3000,
+    strictPort: true,
   },
   optimizeDeps: {
     include: [
@@ -34,7 +35,6 @@ export default defineConfig({
       "react-router-dom",
       "zustand",
       "@tanstack/react-query",
-      "framer-motion",
       "lucide-react",
       "clsx",
       "react-markdown",


### PR DESCRIPTION
Fix dev mode by robustly detecting the Vite dev server URL and passing it to Electron, and improve Vite configuration.

The previous dev script's method of detecting the Vite server URL was unreliable, causing Electron to fail to load the renderer in dev mode. This PR implements robust URL extraction, passes it explicitly to Electron via an environment variable, and configures Vite with `strictPort: true` to prevent unexpected port usage. It also removes an uninstalled dependency from `optimizeDeps`.

---
<a href="https://cursor.com/background-agent?bcId=bc-022e233d-9533-4cb7-b84b-5447a4228d61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-022e233d-9533-4cb7-b84b-5447a4228d61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

