### PR TITLE
Update icon updater for 80% shrink

### DIFF
--- a/generate-icons.sh
+++ b/generate-icons.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Icon generation script with 80% shrink for macOS dock
+# This script addresses the issue where Electron app icons appear too large
+# in the macOS dock by creating icons that are 80% of their target size
+# with transparent padding around them.
+
 set -euo pipefail
 
 # Check if ImageMagick is installed
@@ -15,17 +20,30 @@ if [ ! -f "$INPUT" ]; then
     exit 1
 fi
 
-echo "Creating rounded corner icons from $INPUT..."
+echo "Creating rounded corner icons with 80% shrink (macOS dock padding) from $INPUT..."
 
-# Function to create rounded corners
+# Function to create rounded corners with 80% shrink (padding for macOS dock)
+# This addresses the issue where Electron app icons appear too large in the macOS dock
+# by creating icons that are 80% of their target size with transparent padding
 create_rounded() {
     local input="$1"
     local output="$2"
     local size="$3"
     local radius=$((size / 8))  # 12.5% radius for nice rounded corners
     
+    # Calculate 80% of the target size for the actual icon content
+    # This creates the visual effect of the icon being 80% of its original size
+    local icon_size=$((size * 80 / 100))
+    local padding=$((size - icon_size))
+    
+    # Step 1: Resize the input image to 80% of the target size
+    # Step 2: Add transparent padding to center the icon within the full target size
+    # Step 3: Apply rounded corners to the final result
     magick "$input" \
-        -resize "${size}x${size}" \
+        -resize "${icon_size}x${icon_size}" \
+        -background transparent \
+        -gravity center \
+        -extent "${size}x${size}" \
         \( +clone -alpha extract \
            -draw "fill black polygon 0,0 0,$radius $radius,0 fill white circle $radius,$radius $radius,0" \
            \( +clone -flip \) -compose Multiply -composite \
@@ -80,13 +98,13 @@ create_rounded "$INPUT" "1024-rounded.png" 1024
 echo "✓ Created 1024-rounded.png"
 
 echo ""
-echo "✅ All icons generated successfully!"
+echo "✅ All icons generated successfully with 80% shrink for macOS dock!"
 echo ""
 echo "Files created:"
-echo "  - icon.icns (macOS)"
+echo "  - icon.icns (macOS with 80% shrink padding)"
 echo "  - icon.ico (Windows)"
 echo "  - icons/*.png (Linux)"
-echo "  - 1024-rounded.png (source with rounded corners)"
+echo "  - 1024-rounded.png (source with rounded corners and 80% shrink)"
 echo ""
 echo "To use the rounded version as your app icon, run:"
 echo "  mv 1024-rounded.png 1024.png"


### PR DESCRIPTION
Update icon generation script to apply an 80% shrink with padding for macOS dock icons.

This addresses an issue where Electron app icons appear too large in the macOS dock by resizing the icon content to 80% of the target size and adding transparent padding.

---
<a href="https://cursor.com/background-agent?bcId=bc-64f0010e-719e-4624-8ff4-aded9504665a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-64f0010e-719e-4624-8ff4-aded9504665a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

