### PR TITLE
Fix pull request closure UI update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bottleneck",
-  "version": "0.1.8",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bottleneck",
-      "version": "0.1.8",
+      "version": "0.1.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/renderer/components/PRTreeView.tsx
+++ b/src/renderer/components/PRTreeView.tsx
@@ -421,14 +421,16 @@ export function PRTreeView({
                         onClick={(event) => {
                           event.stopPropagation();
                           onCloseGroup(item.data.closablePRIds ?? []);
-                          setHoveredGroup(null);
+                          // Don't immediately clear hover - let the UI update be visible
+                          setTimeout(() => setHoveredGroup(null), 500);
                         }}
                         onKeyDown={(event) => {
                           if (event.key === 'Enter' || event.key === ' ') {
                             event.preventDefault();
                             event.stopPropagation();
                             onCloseGroup(item.data.closablePRIds ?? []);
-                            setHoveredGroup(null);
+                            // Don't immediately clear hover - let the UI update be visible
+                            setTimeout(() => setHoveredGroup(null), 500);
                           }
                         }}
                         className={cn(

--- a/src/renderer/views/PRListView.tsx
+++ b/src/renderer/views/PRListView.tsx
@@ -526,8 +526,11 @@ export default function PRListView() {
   const handleCloseGroup = useCallback(
     async (prIds: string[]) => {
       await closePRIds(prIds);
+      // Force a re-render by updating the filter state
+      // This ensures the UI updates immediately after closing PRs
+      setPRListFilters(prev => ({ ...prev }));
     },
-    [closePRIds],
+    [closePRIds, setPRListFilters],
   );
 
   const hasSelection = selectedPRs.size > 0;
@@ -911,7 +914,7 @@ export default function PRListView() {
           </div>
         ) : (
           <PRTreeView
-            key={`${Array.from(selectedStatuses).join('-')}-${Array.from(selectedAuthors).join('-')}`}
+            key={`${Array.from(selectedStatuses).join('-')}-${Array.from(selectedAuthors).join('-')}-${prsWithMetadata.filter(p => p.pr.state === 'open').length}-${prsWithMetadata.filter(p => p.pr.state === 'closed').length}`}
             theme={theme}
             prsWithMetadata={prsWithMetadata}
             selectedPRs={selectedPRs}


### PR DESCRIPTION
Fixes the issue where the UI does not immediately update after closing unmerged PRs.

The `PRTreeView` component wasn't re-rendering correctly due to an insufficient `key` prop and immediate clearing of hover state, and the `handleCloseGroup` function didn't explicitly trigger a re-render after closing PRs.

---
<a href="https://cursor.com/background-agent?bcId=bc-1cbb04c9-c605-4dbc-aa3a-2400f60bbed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1cbb04c9-c605-4dbc-aa3a-2400f60bbed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

