### PR TITLE
Fix pull request closure UI update

### DIFF
--- a/src/renderer/components/PRTreeView.tsx
+++ b/src/renderer/components/PRTreeView.tsx
@@ -231,6 +231,7 @@ export function PRTreeView({
     <span className="pr-tree-view-container">
       <div className="flex-1 overflow-y-auto">
         <UncontrolledTreeEnvironment
+          key={JSON.stringify(Object.keys(treeItems))}
           dataProvider={treeDataProvider}
           renderDepthOffset={24}
           getItemTitle={(item) => {

--- a/src/renderer/views/PRListView.tsx
+++ b/src/renderer/views/PRListView.tsx
@@ -911,7 +911,7 @@ export default function PRListView() {
           </div>
         ) : (
           <PRTreeView
-            key={`${Array.from(selectedStatuses).join('-')}-${Array.from(selectedAuthors).join('-')}`}
+            key={`${Array.from(selectedStatuses).join('-')}-${Array.from(selectedAuthors).join('-')}-${getFilteredPRs.length}`}
             theme={theme}
             prsWithMetadata={prsWithMetadata}
             selectedPRs={selectedPRs}


### PR DESCRIPTION
Update PRTreeView and UncontrolledTreeEnvironment keys to ensure immediate UI refresh after closing PRs.

The UI was not immediately updating after "Close unmerged PRs?" because the `PRTreeView` and its child `UncontrolledTreeEnvironment` were not re-rendering. Their `key` props were not reactive to changes in the number of filtered PRs or the tree item structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-1125f444-b7e0-45dc-b257-5ede5252c57a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1125f444-b7e0-45dc-b257-5ede5252c57a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

