### PR TITLE
Fix pull request closure UI update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bottleneck",
-  "version": "0.1.8",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bottleneck",
-      "version": "0.1.8",
+      "version": "0.1.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Add a loading state and visual feedback for "Close unmerged PRs?" to prevent the button from disappearing immediately.

The button's visibility was tied to the hover state, which was immediately reset on click. This PR introduces a `closingGroup` state to maintain visibility and display a "Closing..." message during the asynchronous operation, improving user experience by providing immediate feedback and preventing accidental double-clicks.

---
<a href="https://cursor.com/background-agent?bcId=bc-db246156-34e9-4eb6-88db-bcb09636bec0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-db246156-34e9-4eb6-88db-bcb09636bec0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

