### PR TITLE
Enable native find in page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bottleneck",
-  "version": "0.1.8",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bottleneck",
-      "version": "0.1.8",
+      "version": "0.1.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -81,6 +81,15 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
               { role: "selectAll" as const },
               { type: "separator" as const },
               {
+                label: "Find",
+                accelerator: "CmdOrCtrl+F",
+                click: () => {
+                  // Show the native find bar
+                  mainWindow.webContents.findInPage("");
+                },
+              },
+              { type: "separator" as const },
+              {
                 label: "Speech",
                 submenu: [
                   { role: "startSpeaking" as const },
@@ -92,6 +101,15 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
               { role: "delete" as const },
               { type: "separator" as const },
               { role: "selectAll" as const },
+              { type: "separator" as const },
+              {
+                label: "Find",
+                accelerator: "CmdOrCtrl+F",
+                click: () => {
+                  // Show the native find bar
+                  mainWindow.webContents.findInPage("");
+                },
+              },
             ]),
       ],
     },


### PR DESCRIPTION
Enable native Electron find-in-page functionality to allow users to search within the current page using Cmd/Ctrl+F.

The standard Cmd/Ctrl+F shortcut for find-in-page was not working. This PR adds a "Find" menu item with the `CmdOrCtrl+F` accelerator that calls `mainWindow.webContents.findInPage("")`, which triggers the native Electron find bar and its associated functionality (highlighting, match counting, and keyboard shortcuts).

---
<a href="https://cursor.com/background-agent?bcId=bc-c412f691-507c-435d-bbe7-e40107a7f039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c412f691-507c-435d-bbe7-e40107a7f039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



Relates to #32

Fixes #32