### PR TITLE
Add pre-saved author teams for filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bottleneck",
-  "version": "0.1.8",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bottleneck",
-      "version": "0.1.8",
+      "version": "0.1.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/renderer/components/TeamManagerModal.tsx
+++ b/src/renderer/components/TeamManagerModal.tsx
@@ -1,0 +1,248 @@
+import React, { useMemo, useState } from "react";
+import { X, Plus, Trash2 } from "lucide-react";
+import { useUIStore } from "../stores/uiStore";
+import { AuthorTeam, useSettingsStore } from "../stores/settingsStore";
+import { cn } from "../utils/cn";
+
+interface TeamManagerModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  availableAuthors: { login: string; avatar_url: string }[];
+  initialEditingTeamId?: string | null;
+}
+
+export default function TeamManagerModal({
+  isOpen,
+  onClose,
+  availableAuthors,
+  initialEditingTeamId = null,
+}: TeamManagerModalProps) {
+  const { theme } = useUIStore();
+  const { settings, addAuthorTeam, updateAuthorTeam, deleteAuthorTeam } = useSettingsStore();
+  const [editingId, setEditingId] = useState<string | null>(initialEditingTeamId);
+
+  const editingTeam = useMemo<AuthorTeam | null>(() => {
+    return (settings.authorTeams || []).find((t) => t.id === editingId) || null;
+  }, [settings.authorTeams, editingId]);
+
+  const [name, setName] = useState<string>(editingTeam?.name || "");
+  const [description, setDescription] = useState<string>(editingTeam?.description || "");
+  const [color, setColor] = useState<string>(editingTeam?.color || "");
+  const [icon, setIcon] = useState<string>(editingTeam?.icon || "");
+  const [members, setMembers] = useState<string[]>(editingTeam?.members || []);
+
+  React.useEffect(() => {
+    if (editingTeam) {
+      setName(editingTeam.name || "");
+      setDescription(editingTeam.description || "");
+      setColor(editingTeam.color || "");
+      setIcon(editingTeam.icon || "");
+      setMembers(editingTeam.members || []);
+    } else {
+      setName("");
+      setDescription("");
+      setColor("");
+      setIcon("");
+      setMembers([]);
+    }
+  }, [editingTeam]);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (editingId && editingTeam) {
+      updateAuthorTeam({
+        id: editingTeam.id,
+        name: name.trim() || editingTeam.name,
+        members,
+        color: color || undefined,
+        icon: icon || undefined,
+        description: description || undefined,
+      });
+    } else {
+      addAuthorTeam({
+        name: name.trim() || "Untitled Team",
+        members,
+        color: color || undefined,
+        icon: icon || undefined,
+        description: description || undefined,
+      });
+    }
+    onClose();
+  };
+
+  const toggleMember = (login: string) => {
+    setMembers((prev) => {
+      const next = new Set(prev);
+      if (next.has(login)) next.delete(login);
+      else next.add(login);
+      return Array.from(next);
+    });
+  };
+
+  const handleDelete = () => {
+    if (editingId) {
+      deleteAuthorTeam(editingId);
+      setEditingId(null);
+      onClose();
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        className={cn(
+          "absolute inset-0 bg-black/50",
+          theme === "dark" ? "backdrop-blur-sm" : "backdrop-blur-sm",
+        )}
+        onClick={onClose}
+      />
+
+      <div
+        className={cn(
+          "relative z-10 w-full max-w-lg rounded-md shadow-lg border",
+          theme === "dark" ? "bg-gray-800 border-gray-700" : "bg-white border-gray-200",
+        )}
+      >
+        <div className="flex items-center justify-between p-4 border-b border-gray-700/30">
+          <h2 className="text-lg font-semibold">
+            {editingId ? "Edit Team" : "Create New Team"}
+          </h2>
+          <button onClick={onClose} className="p-1 hover:opacity-80">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-4 space-y-4">
+          <div>
+            <label className="block text-xs mb-1">Name</label>
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Frontend Team"
+              className={cn(
+                "w-full text-sm px-3 py-2 rounded border",
+                theme === "dark" ? "bg-gray-700 border-gray-600" : "bg-white border-gray-300",
+              )}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs mb-1">Icon (emoji)</label>
+              <input
+                value={icon}
+                onChange={(e) => setIcon(e.target.value)}
+                placeholder="🏢"
+                className={cn(
+                  "w-full text-sm px-3 py-2 rounded border",
+                  theme === "dark" ? "bg-gray-700 border-gray-600" : "bg-white border-gray-300",
+                )}
+              />
+            </div>
+            <div>
+              <label className="block text-xs mb-1">Color</label>
+              <input
+                value={color}
+                onChange={(e) => setColor(e.target.value)}
+                placeholder="#2563eb"
+                className={cn(
+                  "w-full text-sm px-3 py-2 rounded border",
+                  theme === "dark" ? "bg-gray-700 border-gray-600" : "bg-white border-gray-300",
+                )}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-xs mb-1">Description</label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Developers focusing on the frontend surfaces"
+              rows={3}
+              className={cn(
+                "w-full text-sm px-3 py-2 rounded border resize-none",
+                theme === "dark" ? "bg-gray-700 border-gray-600" : "bg-white border-gray-300",
+              )}
+            />
+          </div>
+
+          <div>
+            <div className="flex items-center justify-between">
+              <label className="block text-xs mb-1">Members</label>
+              <span className="text-xs opacity-70">{members.length} selected</span>
+            </div>
+            <div className="max-h-48 overflow-y-auto border rounded p-2 mt-1"
+              style={{ borderColor: theme === "dark" ? "#374151" : "#e5e7eb" }}
+            >
+              {availableAuthors.map((author) => {
+                const checked = members.includes(author.login);
+                return (
+                  <label
+                    key={author.login}
+                    className={cn(
+                      "flex items-center space-x-2 p-2 rounded cursor-pointer",
+                      theme === "dark" ? "hover:bg-gray-700" : "hover:bg-gray-50",
+                    )}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggleMember(author.login)}
+                      className="rounded"
+                    />
+                    <img src={author.avatar_url} alt={author.login} className="w-5 h-5 rounded-full" />
+                    <span className="text-sm">{author.login}</span>
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between pt-2">
+            {editingId ? (
+              <button
+                type="button"
+                onClick={handleDelete}
+                className={cn(
+                  "inline-flex items-center text-xs px-2 py-1 rounded border",
+                  theme === "dark" ? "border-red-800 text-red-300 hover:bg-red-900/20" : "border-red-300 text-red-700 hover:bg-red-50",
+                )}
+              >
+                <Trash2 className="w-3.5 h-3.5 mr-1" /> Delete Team
+              </button>
+            ) : (
+              <span />
+            )}
+
+            <div className="space-x-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className={cn(
+                  "text-xs px-3 py-1 rounded border",
+                  theme === "dark" ? "border-gray-600 hover:bg-gray-700" : "border-gray-300 hover:bg-gray-100",
+                )}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className={cn(
+                  "text-xs px-3 py-1 rounded border",
+                  theme === "dark" ? "border-blue-700 bg-blue-600 text-white hover:bg-blue-500" : "border-blue-300 bg-blue-600 text-white hover:bg-blue-500",
+                )}
+              >
+                {editingId ? "Save" : (
+                  <span className="inline-flex items-center"><Plus className="w-3.5 h-3.5 mr-1" /> Create</span>
+                )}
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/utils/__tests__/teamUtils.test.ts
+++ b/src/renderer/utils/__tests__/teamUtils.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import {
+  areAllTeamMembersSelected,
+  areAnyTeamMembersSelected,
+  addTeamMembersToSelection,
+  removeTeamMembersFromSelection,
+  toggleTeamInSelection,
+  normalizeSelectionAgainstAllToken,
+} from '../teamUtils';
+
+describe('teamUtils', () => {
+  it('areAllTeamMembersSelected works', () => {
+    const sel = new Set(['a', 'b', 'c']);
+    expect(areAllTeamMembersSelected(sel, ['a', 'b'])).toBe(true);
+    expect(areAllTeamMembersSelected(sel, ['a', 'd'])).toBe(false);
+    expect(areAllTeamMembersSelected(sel, [])).toBe(false);
+  });
+
+  it('areAnyTeamMembersSelected works', () => {
+    const sel = new Set(['a', 'b']);
+    expect(areAnyTeamMembersSelected(sel, ['x', 'b'])).toBe(true);
+    expect(areAnyTeamMembersSelected(sel, ['x', 'y'])).toBe(false);
+  });
+
+  it('addTeamMembersToSelection adds and clears all token', () => {
+    const sel = new Set(['all']);
+    const res = addTeamMembersToSelection(sel, ['a', 'b']);
+    expect(res.has('all')).toBe(false);
+    expect(res.has('a')).toBe(true);
+    expect(res.has('b')).toBe(true);
+  });
+
+  it('removeTeamMembersFromSelection removes and clears all token', () => {
+    const sel = new Set(['a', 'b', 'all']);
+    const res = removeTeamMembersFromSelection(sel, ['a']);
+    expect(res.has('a')).toBe(false);
+    expect(res.has('b')).toBe(true);
+    expect(res.has('all')).toBe(false);
+  });
+
+  it('toggleTeamInSelection toggles correctly', () => {
+    const sel = new Set(['a']);
+    const res1 = toggleTeamInSelection(sel, ['a', 'b']);
+    expect(res1.has('a')).toBe(true);
+    expect(res1.has('b')).toBe(true);
+    const res2 = toggleTeamInSelection(res1, ['a', 'b']);
+    expect(res2.has('a')).toBe(false);
+    expect(res2.has('b')).toBe(false);
+  });
+
+  it('normalizeSelectionAgainstAllToken sets all when complete', () => {
+    const allAuthors = ['a', 'b', 'c'];
+    const sel = new Set(['a', 'b', 'c']);
+    const res = normalizeSelectionAgainstAllToken(sel, allAuthors);
+    expect(res.has('all')).toBe(true);
+  });
+
+  it('normalizeSelectionAgainstAllToken removes all when incomplete', () => {
+    const allAuthors = ['a', 'b', 'c'];
+    const sel = new Set(['a', 'b', 'all']);
+    const res = normalizeSelectionAgainstAllToken(sel, allAuthors);
+    expect(res.has('all')).toBe(false);
+  });
+});

--- a/src/renderer/utils/teamUtils.ts
+++ b/src/renderer/utils/teamUtils.ts
@@ -1,0 +1,66 @@
+export function areAllTeamMembersSelected(
+  selectedAuthorLogins: Set<string>,
+  teamMemberLogins: string[],
+): boolean {
+  if (teamMemberLogins.length === 0) return false;
+  return teamMemberLogins.every((login) => selectedAuthorLogins.has(login));
+}
+
+export function areAnyTeamMembersSelected(
+  selectedAuthorLogins: Set<string>,
+  teamMemberLogins: string[],
+): boolean {
+  return teamMemberLogins.some((login) => selectedAuthorLogins.has(login));
+}
+
+export function addTeamMembersToSelection(
+  selectedAuthorLogins: Set<string>,
+  teamMemberLogins: string[],
+): Set<string> {
+  const next = new Set(selectedAuthorLogins);
+  for (const login of teamMemberLogins) {
+    next.add(login);
+  }
+  // Never keep the special "all" token when specific authors are selected
+  next.delete("all");
+  return next;
+}
+
+export function removeTeamMembersFromSelection(
+  selectedAuthorLogins: Set<string>,
+  teamMemberLogins: string[],
+): Set<string> {
+  const next = new Set(selectedAuthorLogins);
+  for (const login of teamMemberLogins) {
+    next.delete(login);
+  }
+  next.delete("all");
+  return next;
+}
+
+export function toggleTeamInSelection(
+  selectedAuthorLogins: Set<string>,
+  teamMemberLogins: string[],
+): Set<string> {
+  const allSelected = areAllTeamMembersSelected(selectedAuthorLogins, teamMemberLogins);
+  return allSelected
+    ? removeTeamMembersFromSelection(selectedAuthorLogins, teamMemberLogins)
+    : addTeamMembersToSelection(selectedAuthorLogins, teamMemberLogins);
+}
+
+export function normalizeSelectionAgainstAllToken(
+  selection: Set<string>,
+  allAuthorLogins: string[],
+): Set<string> {
+  // If the set contains all individual authors, add the special "all" token
+  const hasAllIndividuals = allAuthorLogins.every((login) => selection.has(login));
+  if (hasAllIndividuals) {
+    const next = new Set(selection);
+    next.add("all");
+    return next;
+  }
+  // If not all selected, ensure "all" is not set
+  const next = new Set(selection);
+  next.delete("all");
+  return next;
+}


### PR DESCRIPTION
Adds the ability to save and quick-select author teams in PR and Issue filters to streamline common multi-author filtering workflows.

Users frequently filter by the same groups of people (e.g., frontend team, backend team). This feature allows saving these groups as named "teams" for faster, one-click filtering, improving the user experience by reducing repetitive manual selection of multiple authors.

---
<a href="https://cursor.com/background-agent?bcId=bc-20a80414-146b-4107-a11c-f112489733a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-20a80414-146b-4107-a11c-f112489733a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



Fixes #69