### PR TITLE
Enable native find in page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bottleneck",
-  "version": "0.1.8",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bottleneck",
-      "version": "0.1.8",
+      "version": "0.1.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -528,3 +528,33 @@ ipcMain.handle("updater:get-status", () => {
     currentVersion: app.getVersion()
   };
 });
+
+// Find-in-page IPC handlers
+ipcMain.handle("find:start", () => {
+  if (mainWindow) {
+    mainWindow.webContents.findInPage("");
+    return { success: true };
+  }
+  return { success: false, error: "No window available" };
+});
+
+ipcMain.handle("find:find", (_, text: string, options?: { forward?: boolean; matchCase?: boolean; findNext?: boolean }) => {
+  if (mainWindow) {
+    const findOptions = {
+      forward: options?.forward !== false,
+      matchCase: options?.matchCase || false,
+      findNext: options?.findNext || false
+    };
+    mainWindow.webContents.findInPage(text, findOptions);
+    return { success: true };
+  }
+  return { success: false, error: "No window available" };
+});
+
+ipcMain.handle("find:stop", () => {
+  if (mainWindow) {
+    mainWindow.webContents.stopFindInPage("clearSelection");
+    return { success: true };
+  }
+  return { success: false, error: "No window available" };
+});

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -74,6 +74,28 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
         { role: "cut" },
         { role: "copy" },
         { role: "paste" },
+        { type: "separator" },
+        {
+          label: "Find",
+          accelerator: "CmdOrCtrl+F",
+          click: () => {
+            mainWindow.webContents.findInPage("");
+          },
+        },
+        {
+          label: "Find Next",
+          accelerator: "CmdOrCtrl+G",
+          click: () => {
+            mainWindow.webContents.findInPage("", { findNext: true });
+          },
+        },
+        {
+          label: "Find Previous",
+          accelerator: "CmdOrCtrl+Shift+G",
+          click: () => {
+            mainWindow.webContents.findInPage("", { findNext: false });
+          },
+        },
         ...(isMac
           ? [
               { role: "pasteAndMatchStyle" as const },

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -80,6 +80,14 @@ const electronAPI = {
     clear: () => ipcRenderer.invoke("settings:clear"),
   },
 
+  // Find-in-page operations
+  find: {
+    start: () => ipcRenderer.invoke("find:start"),
+    find: (text: string, options?: { forward?: boolean; matchCase?: boolean; findNext?: boolean }) =>
+      ipcRenderer.invoke("find:find", text, options),
+    stop: () => ipcRenderer.invoke("find:stop"),
+  },
+
   // IPC event listeners
   on: (
     channel: string,

--- a/src/renderer/utils/keyboard.ts
+++ b/src/renderer/utils/keyboard.ts
@@ -73,6 +73,33 @@ export function setupKeyboardShortcuts() {
         useUIStore.getState().toggleWordWrap();
         return;
       }
+
+      // Find in page (Cmd/Ctrl + F)
+      if (e.key === "f" || e.key === "F") {
+        e.preventDefault();
+        if (window.electron) {
+          window.electron.find.start();
+        }
+        return;
+      }
+
+      // Find next (Cmd/Ctrl + G)
+      if (e.key === "g" || e.key === "G") {
+        e.preventDefault();
+        if (window.electron) {
+          window.electron.find.find("", { findNext: true });
+        }
+        return;
+      }
+    }
+
+    // Find previous (Cmd/Ctrl + Shift + G)
+    if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === "g" || e.key === "G")) {
+      e.preventDefault();
+      if (window.electron) {
+        window.electron.find.find("", { findNext: false });
+      }
+      return;
     }
   };
 


### PR DESCRIPTION
Enable native Electron find-in-page functionality to allow users to search within the current page using standard keyboard shortcuts (Cmd/Ctrl+F).

---
<a href="https://cursor.com/background-agent?bcId=bc-317610c0-1232-418f-94c0-2099a5ed9ada"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-317610c0-1232-418f-94c0-2099a5ed9ada"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



Relates to #32

Fixes #32