### PR TITLE
Add pre-saved author teams for filtering

### DIFF
--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -1,5 +1,15 @@
 import { create } from "zustand";
 
+// Saved team of authors for quick filtering
+export interface AuthorTeam {
+  id: string;
+  name: string;
+  members: string[]; // GitHub login names
+  color?: string; // Optional HEX color (e.g. #AABBCC or AABBCC)
+  icon?: string; // Optional emoji or short icon text
+  description?: string;
+}
+
 interface Settings {
   // General
   autoSync: boolean;
@@ -26,6 +36,9 @@ interface Settings {
   cacheSize: number;
   enableDebugMode: boolean;
   enableTelemetry: boolean;
+
+  // Saved author teams for filters
+  authorTeams: AuthorTeam[];
 }
 
 interface SettingsState {
@@ -34,6 +47,12 @@ interface SettingsState {
   loadSettings: () => Promise<void>;
   saveSettings: () => Promise<void>;
   resetSettings: () => void;
+
+  // Team helpers
+  setAuthorTeams: (teams: AuthorTeam[]) => Promise<void>;
+  addAuthorTeam: (team: Omit<AuthorTeam, "id"> & { id?: string }) => Promise<AuthorTeam>;
+  updateAuthorTeam: (team: AuthorTeam) => Promise<void>;
+  deleteAuthorTeam: (teamId: string) => Promise<void>;
 }
 
 const defaultSettings: Settings = {
@@ -62,6 +81,9 @@ const defaultSettings: Settings = {
   cacheSize: 500,
   enableDebugMode: false,
   enableTelemetry: false,
+
+  // Teams
+  authorTeams: [],
 };
 
 export const useSettingsStore = create<SettingsState>((set, get) => ({
@@ -78,9 +100,9 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     console.log("⏱️ [SETTINGS] loadSettings started");
 
     try {
-      // Load from electron store
-      if (window.electron?.settings) {
-        const result = await window.electron.settings.get();
+      // Load from electron store (only in renderer)
+      if (typeof window !== "undefined" && (window as any).electron?.settings) {
+        const result = await (window as any).electron.settings.get();
         if (result.success && result.settings) {
           set({ settings: { ...defaultSettings, ...result.settings } });
           console.log(`⏱️ [SETTINGS] Settings loaded in ${(performance.now() - start).toFixed(2)}ms`);
@@ -93,11 +115,11 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
 
   saveSettings: async () => {
     try {
-      // Save to electron store
-      if (window.electron?.settings) {
+      // Save to electron store (only in renderer)
+      if (typeof window !== "undefined" && (window as any).electron?.settings) {
         const settings = get().settings;
         for (const [key, value] of Object.entries(settings)) {
-          await window.electron.settings.set(key, value);
+          await (window as any).electron.settings.set(key, value);
         }
       }
     } catch (error) {
@@ -107,5 +129,78 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
 
   resetSettings: () => {
     set({ settings: defaultSettings });
+  },
+
+  // Team helpers
+  setAuthorTeams: async (teams) => {
+    set((state) => ({ settings: { ...state.settings, authorTeams: teams } }));
+    try {
+      if (typeof window !== "undefined" && (window as any).electron?.settings?.set) {
+        await (window as any).electron.settings.set("authorTeams", teams);
+      }
+    } catch (error) {
+      console.error("Failed to persist authorTeams:", error);
+    }
+  },
+  addAuthorTeam: async (team) => {
+    const generateId = () =>
+      `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+    const id = team.id || generateId();
+    const newTeam: AuthorTeam = {
+      id,
+      name: team.name?.trim() || "Untitled Team",
+      members: Array.from(new Set(team.members || [])).sort(),
+      color: team.color,
+      icon: team.icon,
+      description: team.description,
+    };
+
+    const currentTeams = get().settings.authorTeams || [];
+    const nextTeams = [...currentTeams, newTeam];
+    set({ settings: { ...get().settings, authorTeams: nextTeams } });
+    try {
+      if (typeof window !== "undefined" && (window as any).electron?.settings?.set) {
+        await (window as any).electron.settings.set("authorTeams", nextTeams);
+      }
+    } catch (error) {
+      console.error("Failed to persist authorTeams:", error);
+    }
+    return newTeam;
+  },
+  updateAuthorTeam: async (updated) => {
+    const currentTeams = get().settings.authorTeams || [];
+    const nextTeams = currentTeams.map((t) =>
+      t.id === updated.id
+        ? {
+            ...t,
+            name: updated.name?.trim() || t.name,
+            members: Array.from(new Set(updated.members || [])).sort(),
+            color: updated.color,
+            icon: updated.icon,
+            description: updated.description,
+          }
+        : t,
+    );
+    set({ settings: { ...get().settings, authorTeams: nextTeams } });
+    try {
+      if (typeof window !== "undefined" && (window as any).electron?.settings?.set) {
+        await (window as any).electron.settings.set("authorTeams", nextTeams);
+      }
+    } catch (error) {
+      console.error("Failed to persist authorTeams:", error);
+    }
+  },
+  deleteAuthorTeam: async (teamId) => {
+    const currentTeams = get().settings.authorTeams || [];
+    const nextTeams = currentTeams.filter((t) => t.id !== teamId);
+    set({ settings: { ...get().settings, authorTeams: nextTeams } });
+    try {
+      if (typeof window !== "undefined" && (window as any).electron?.settings?.set) {
+        await (window as any).electron.settings.set("authorTeams", nextTeams);
+      }
+    } catch (error) {
+      console.error("Failed to persist authorTeams:", error);
+    }
   },
 }));

--- a/src/renderer/utils/__tests__/teams.test.ts
+++ b/src/renderer/utils/__tests__/teams.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { useSettingsStore, type AuthorTeam } from "../../stores/settingsStore";
+
+describe("AuthorTeams store helpers", () => {
+  it("adds, updates, and deletes an author team", async () => {
+    const store = useSettingsStore.getState();
+    await store.setAuthorTeams([]);
+
+    const created = await store.addAuthorTeam({
+      name: "Frontend Team",
+      members: ["alice", "bob"],
+      color: "aabbcc",
+      icon: "🏢",
+      description: "FE group",
+    });
+
+    let teams = useSettingsStore.getState().settings.authorTeams;
+    expect(teams.length).toBe(1);
+    expect(teams[0].name).toBe("Frontend Team");
+    expect(teams[0].members).toEqual(["alice", "bob"]);
+
+    await store.updateAuthorTeam({
+      ...created,
+      name: "Frontend",
+      members: ["alice", "bob", "carol"],
+    } as AuthorTeam);
+
+    teams = useSettingsStore.getState().settings.authorTeams;
+    expect(teams[0].name).toBe("Frontend");
+    expect(teams[0].members).toEqual(["alice", "bob", "carol"]);
+
+    await store.deleteAuthorTeam(created.id);
+    teams = useSettingsStore.getState().settings.authorTeams;
+    expect(teams.length).toBe(0);
+  });
+});

--- a/src/renderer/views/PRListView.tsx
+++ b/src/renderer/views/PRListView.tsx
@@ -1,12 +1,13 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
-import { GitPullRequest } from "lucide-react";
+import { GitPullRequest, Users, Plus, Pencil, Trash2 } from "lucide-react";
 import { usePRStore } from "../stores/prStore";
 import { useUIStore } from "../stores/uiStore";
 import { useAuthStore } from "../stores/authStore";
 import Dropdown, { DropdownOption } from "../components/Dropdown";
 import { detectAgentName } from "../utils/agentIcons";
 import { getTitlePrefix } from "../utils/prUtils";
+import { useSettingsStore, type AuthorTeam } from "../stores/settingsStore";
 import { getPRStatus, PRStatusType } from "../utils/prStatus";
 import { cn } from "../utils/cn";
 import WelcomeView from "./WelcomeView";
@@ -55,6 +56,24 @@ export default function PRListView() {
   const [showStatusDropdown, setShowStatusDropdown] = useState(false);
   const statusDropdownRef = useRef<HTMLDivElement>(null);
   const [isClosing, setIsClosing] = useState(false);
+
+  // Saved teams
+  const {
+    settings,
+    addAuthorTeam,
+    updateAuthorTeam,
+    deleteAuthorTeam,
+  } = useSettingsStore();
+  const teams = settings.authorTeams || [];
+  const [showTeamEditor, setShowTeamEditor] = useState(false);
+  const [editingTeam, setEditingTeam] = useState<AuthorTeam | null>(null);
+  const [teamForm, setTeamForm] = useState<{
+    name: string;
+    members: string[];
+    color?: string;
+    icon?: string;
+    description?: string;
+  }>({ name: "", members: [], color: "", icon: "", description: "" });
 
   const sortBy = prListFilters.sortBy;
   const selectedAuthors = useMemo(
@@ -184,6 +203,82 @@ export default function PRListView() {
     });
     return Array.from(authorMap.values());
   }, [pullRequests]);
+
+  const isTeamSelected = useCallback(
+    (team: AuthorTeam) => {
+      if (selectedAuthors.has("all")) return true;
+      return team.members.length > 0 && team.members.every((m) => selectedAuthors.has(m));
+    },
+    [selectedAuthors],
+  );
+
+  const handleTeamToggle = useCallback(
+    (team: AuthorTeam) => {
+      setPRListFilters((prev) => {
+        const next = new Set(prev.selectedAuthors);
+        // Deselect "all" when toggling teams to avoid confusion
+        next.delete("all");
+
+        const isSelected = team.members.every((m) => next.has(m));
+        if (isSelected) {
+          // Remove team members
+          team.members.forEach((m) => next.delete(m));
+        } else {
+          // Add team members
+          team.members.forEach((m) => next.add(m));
+        }
+
+        // Re-add "all" if all authors are now selected
+        const allAuthorLogins = authors.map((a) => a.login);
+        if (allAuthorLogins.length > 0 && allAuthorLogins.every((login) => next.has(login))) {
+          next.add("all");
+        }
+
+        return { ...prev, selectedAuthors: Array.from(next) };
+      });
+    },
+    [authors, setPRListFilters],
+  );
+
+  const startCreateTeam = useCallback(() => {
+    const currentMembers = Array.from(selectedAuthors).filter((a) => a !== "all");
+    setEditingTeam(null);
+    setTeamForm({ name: "", members: currentMembers, color: "", icon: "", description: "" });
+    setShowTeamEditor(true);
+  }, [selectedAuthors]);
+
+  const startEditTeam = useCallback((team: AuthorTeam) => {
+    setEditingTeam(team);
+    setTeamForm({
+      name: team.name,
+      members: [...team.members],
+      color: team.color || "",
+      icon: team.icon || "",
+      description: team.description || "",
+    });
+    setShowTeamEditor(true);
+  }, []);
+
+  const saveTeam = useCallback(async () => {
+    const payload = {
+      name: teamForm.name.trim() || "Untitled Team",
+      members: Array.from(new Set(teamForm.members)).filter(Boolean),
+      color: teamForm.color || undefined,
+      icon: teamForm.icon || undefined,
+      description: teamForm.description || undefined,
+    };
+    if (editingTeam) {
+      await updateAuthorTeam({ ...editingTeam, ...payload });
+    } else {
+      await addAuthorTeam(payload);
+    }
+    setShowTeamEditor(false);
+    setEditingTeam(null);
+  }, [teamForm, editingTeam, addAuthorTeam, updateAuthorTeam]);
+
+  const handleDeleteTeam = useCallback(async (teamId: string) => {
+    await deleteAuthorTeam(teamId);
+  }, [deleteAuthorTeam]);
 
   const handleAuthorToggle = useCallback(
     (authorLogin: string) => {
@@ -822,7 +917,188 @@ export default function PRListView() {
                         : "bg-white border-gray-200"
                     )}
                   >
-                    <div className="p-2 max-h-64 overflow-y-auto">
+                    <div className="p-2 max-h-96 overflow-y-auto">
+                      {/* Teams section */}
+                      <div className="px-1 py-1">
+                        <div className={cn(
+                          "text-[11px] font-semibold uppercase tracking-wide mb-1",
+                          theme === "dark" ? "text-gray-400" : "text-gray-500"
+                        )}>Teams</div>
+
+                        {teams.length === 0 ? (
+                          <div className={cn(
+                            "text-xs px-2 py-1",
+                            theme === "dark" ? "text-gray-400" : "text-gray-600"
+                          )}>No saved teams yet.</div>
+                        ) : (
+                          <div className="space-y-1">
+                            {teams.map((team) => (
+                              <div key={team.id} className="flex items-center justify-between group">
+                                <label
+                                  className={cn(
+                                    "flex items-center space-x-2 p-2 rounded cursor-pointer flex-1",
+                                    theme === "dark" ? "hover:bg-gray-700" : "hover:bg-gray-50"
+                                  )}
+                                >
+                                  <input
+                                    type="checkbox"
+                                    checked={isTeamSelected(team)}
+                                    onChange={() => handleTeamToggle(team)}
+                                    className="rounded"
+                                  />
+                                  <span className="flex items-center space-x-2 min-w-0">
+                                    <span className={cn(
+                                      "w-5 h-5 inline-flex items-center justify-center rounded-sm border text-[11px]",
+                                      theme === "dark" ? "border-gray-600" : "border-gray-300"
+                                    )}
+                                      style={{ backgroundColor: team.color && team.color.startsWith('#') ? team.color : (team.color ? `#${team.color}` : undefined) }}
+                                      title={team.description || undefined}
+                                    >
+                                      {team.icon ? team.icon : <Users className="w-3.5 h-3.5" />}
+                                    </span>
+                                    <span className="truncate text-sm">
+                                      {team.name}
+                                      <span className={cn("ml-1 text-[11px]", theme === "dark" ? "text-gray-400" : "text-gray-500")}>
+                                        ({team.members.length})
+                                      </span>
+                                    </span>
+                                  </span>
+                                </label>
+                                <div className="opacity-0 group-hover:opacity-100 transition-opacity flex items-center space-x-1 pr-1">
+                                  <button
+                                    onClick={(e) => { e.stopPropagation(); startEditTeam(team); }}
+                                    className={cn(
+                                      "p-1 rounded",
+                                      theme === "dark" ? "hover:bg-gray-700" : "hover:bg-gray-100"
+                                    )}
+                                    title="Edit team"
+                                  >
+                                    <Pencil className={cn("w-3.5 h-3.5", theme === "dark" ? "text-gray-300" : "text-gray-600")} />
+                                  </button>
+                                  <button
+                                    onClick={(e) => { e.stopPropagation(); handleDeleteTeam(team.id); }}
+                                    className={cn(
+                                      "p-1 rounded",
+                                      theme === "dark" ? "hover:bg-gray-700" : "hover:bg-gray-100"
+                                    )}
+                                    title="Delete team"
+                                  >
+                                    <Trash2 className="w-3.5 h-3.5 text-red-500" />
+                                  </button>
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+
+                        <div
+                          onClick={(e) => { e.stopPropagation(); startCreateTeam(); }}
+                          className={cn(
+                            "mt-1 text-xs px-2 py-1 rounded cursor-pointer inline-flex items-center",
+                            theme === "dark" ? "hover:bg-gray-700 text-gray-200" : "hover:bg-gray-100 text-gray-700"
+                          )}
+                        >
+                          <Plus className="w-3.5 h-3.5 mr-1" /> Create New Team…
+                        </div>
+                      </div>
+
+                      {showTeamEditor && (
+                        <div className={cn(
+                          "mt-2 p-2 rounded border",
+                          theme === "dark" ? "border-gray-700 bg-gray-900" : "border-gray-200 bg-gray-50"
+                        )}
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <div className="text-xs font-medium mb-2">{editingTeam ? "Edit Team" : "Create Team"}</div>
+                          <div className="space-y-2">
+                            <div className="flex items-center space-x-2">
+                              <input
+                                type="text"
+                                value={teamForm.name}
+                                onChange={(e) => setTeamForm({ ...teamForm, name: e.target.value })}
+                                placeholder="Team name"
+                                className={cn(
+                                  "text-xs px-2 py-1 rounded border w-full",
+                                  theme === "dark" ? "bg-gray-800 border-gray-700 text-gray-200" : "bg-white border-gray-300 text-gray-900"
+                                )}
+                              />
+                            </div>
+                            <div className={cn(
+                              "text-[11px] font-semibold uppercase tracking-wide",
+                              theme === "dark" ? "text-gray-400" : "text-gray-500"
+                            )}>Members</div>
+                            <div className="grid grid-cols-2 gap-1 max-h-32 overflow-auto pr-1">
+                              {authors.map((author) => (
+                                <label key={author.login} className="flex items-center space-x-2 p-1 rounded cursor-pointer">
+                                  <input
+                                    type="checkbox"
+                                    checked={teamForm.members.includes(author.login)}
+                                    onChange={(e) => {
+                                      const next = new Set(teamForm.members);
+                                      if (e.target.checked) next.add(author.login); else next.delete(author.login);
+                                      setTeamForm({ ...teamForm, members: Array.from(next) });
+                                    }}
+                                    className="rounded"
+                                  />
+                                  <img src={author.avatar_url} alt={author.login} className="w-4 h-4 rounded-full" />
+                                  <span className="text-xs">{author.login}</span>
+                                </label>
+                              ))}
+                            </div>
+                            <div className="flex items-center space-x-2">
+                              <input
+                                type="text"
+                                value={teamForm.icon}
+                                onChange={(e) => setTeamForm({ ...teamForm, icon: e.target.value })}
+                                placeholder="Icon (emoji or text)"
+                                className={cn(
+                                  "text-xs px-2 py-1 rounded border w-1/3",
+                                  theme === "dark" ? "bg-gray-800 border-gray-700 text-gray-200" : "bg-white border-gray-300 text-gray-900"
+                                )}
+                              />
+                              <input
+                                type="text"
+                                value={teamForm.color}
+                                onChange={(e) => setTeamForm({ ...teamForm, color: e.target.value })}
+                                placeholder="Color (hex)"
+                                className={cn(
+                                  "text-xs px-2 py-1 rounded border w-1/3",
+                                  theme === "dark" ? "bg-gray-800 border-gray-700 text-gray-200" : "bg-white border-gray-300 text-gray-900"
+                                )}
+                              />
+                              <input
+                                type="text"
+                                value={teamForm.description}
+                                onChange={(e) => setTeamForm({ ...teamForm, description: e.target.value })}
+                                placeholder="Description (optional)"
+                                className={cn(
+                                  "text-xs px-2 py-1 rounded border flex-1",
+                                  theme === "dark" ? "bg-gray-800 border-gray-700 text-gray-200" : "bg-white border-gray-300 text-gray-900"
+                                )}
+                              />
+                            </div>
+                            <div className="flex items-center justify-end space-x-2">
+                              <button
+                                onClick={() => { setShowTeamEditor(false); setEditingTeam(null); }}
+                                className={cn(
+                                  "px-2 py-1 text-xs rounded border",
+                                  theme === "dark" ? "border-gray-700 hover:bg-gray-800" : "border-gray-300 hover:bg-gray-100"
+                                )}
+                              >Cancel</button>
+                              <button
+                                onClick={saveTeam}
+                                disabled={teamForm.members.length === 0 || teamForm.name.trim().length === 0}
+                                className={cn(
+                                  "px-2 py-1 text-xs rounded border font-medium",
+                                  theme === "dark" ? "border-blue-700 bg-blue-900/40 text-blue-300 hover:bg-blue-900/60" : "border-blue-300 bg-blue-50 text-blue-700 hover:bg-blue-100",
+                                  (teamForm.members.length === 0 || teamForm.name.trim().length === 0) && "opacity-60 cursor-not-allowed"
+                                )}
+                              >Save</button>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+
                       {/* All Authors option */}
                       <label
                         className={cn(


### PR DESCRIPTION
Add pre-saved author teams to the PR and Issue author filters to allow quick selection of common author groups. (Refs #69)

This feature addresses the user need to repeatedly select the same combinations of authors (e.g., "Frontend Team", "Backend Team") when filtering PRs and issues. It introduces a "Teams" section in the author dropdowns, enabling users to create, edit, delete, and quickly apply these pre-defined groups.

---
<a href="https://cursor.com/background-agent?bcId=bc-80f72614-ba46-43a8-9933-03dfb0360419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-80f72614-ba46-43a8-9933-03dfb0360419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



Fixes #69