### PR TITLE
Enable native find in page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bottleneck",
-  "version": "0.1.8",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bottleneck",
-      "version": "0.1.8",
+      "version": "0.1.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -93,6 +93,14 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
               { type: "separator" as const },
               { role: "selectAll" as const },
             ]),
+        { type: "separator" },
+        {
+          label: "Find",
+          accelerator: "CmdOrCtrl+F",
+          click: () => {
+            mainWindow.webContents.send("toggle-find");
+          },
+        },
       ],
     },
     {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -34,6 +34,14 @@ const electronAPI = {
     getZoomLevel: () => ipcRenderer.invoke("app:get-zoom-level"),
   },
 
+  // Find-in-page
+  find: {
+    search: (text: string, options?: { forward?: boolean; findNext?: boolean }) =>
+      ipcRenderer.send("find-in-page", text, options),
+    stop: (action?: "clearSelection" | "keepSelection" | "activateSelection") =>
+      ipcRenderer.send("stop-find-in-page", action),
+  },
+
   // Auto-updater
   updater: {
     checkForUpdates: () => ipcRenderer.invoke("updater:check-for-updates"),
@@ -108,6 +116,7 @@ const electronAPI = {
       "toggle-diff-view",
       "toggle-whitespace",
       "show-shortcuts",
+      "toggle-find",
     ];
 
     if (validChannels.includes(channel)) {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -9,6 +9,7 @@ import Sidebar from "./components/Sidebar";
 import TopBar from "./components/TopBar";
 import RightPanel from "./components/RightPanel";
 import CommandPalette from "./components/CommandPalette";
+import { FindBar } from "./components/FindBar";
 import { setupKeyboardShortcuts } from "./utils/keyboard";
 import { cn } from "./utils/cn";
 import { PerfLogger } from "./utils/perfLogger";
@@ -36,6 +37,7 @@ function App() {
   const { loadSettings } = useSettingsStore();
   const { fetchRepositories } = usePRStore();
   const [loading, setLoading] = useState(true);
+  const [findBarOpen, setFindBarOpen] = useState(false);
 
   PerfLogger.mark("App hooks initialized");
 
@@ -66,6 +68,11 @@ function App() {
       const keyboardStart = performance.now();
       const cleanup = setupKeyboardShortcuts();
       console.log(`⏱️ [APP] Keyboard shortcuts setup in ${(performance.now() - keyboardStart).toFixed(2)}ms`);
+
+      // Set up find bar toggle listener
+      window.electron.on("toggle-find", () => {
+        setFindBarOpen((prev) => !prev);
+      });
 
       return () => {
         clearTimeout(timeoutId);
@@ -204,6 +211,8 @@ function App() {
       </div>
       {/* Command Palette Overlay */}
       <CommandPalette />
+      {/* Find Bar */}
+      <FindBar isOpen={findBarOpen} onClose={() => setFindBarOpen(false)} />
     </div>
   );
 }

--- a/src/renderer/components/FindBar.tsx
+++ b/src/renderer/components/FindBar.tsx
@@ -1,0 +1,103 @@
+import React, { useState, useEffect, useRef } from "react";
+
+interface FindBarProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function FindBar({ isOpen, onClose }: FindBarProps) {
+  const [searchText, setSearchText] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isOpen && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        handleClose();
+      } else if (e.key === "Enter") {
+        if (e.shiftKey) {
+          findPrevious();
+        } else {
+          findNext();
+        }
+      }
+    };
+
+    if (isOpen) {
+      window.addEventListener("keydown", handleEscape);
+      return () => window.removeEventListener("keydown", handleEscape);
+    }
+  }, [isOpen, searchText]);
+
+  const handleClose = () => {
+    window.electron.find.stop("clearSelection");
+    setSearchText("");
+    onClose();
+  };
+
+  const handleSearch = (text: string) => {
+    setSearchText(text);
+    if (text) {
+      window.electron.find.search(text);
+    } else {
+      window.electron.find.stop("clearSelection");
+    }
+  };
+
+  const findNext = () => {
+    if (searchText) {
+      window.electron.find.search(searchText, { forward: true, findNext: true });
+    }
+  };
+
+  const findPrevious = () => {
+    if (searchText) {
+      window.electron.find.search(searchText, { forward: false, findNext: true });
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed top-0 right-4 z-50 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-b-md shadow-lg flex items-center gap-2 p-2">
+      <input
+        ref={inputRef}
+        type="text"
+        value={searchText}
+        onChange={(e) => handleSearch(e.target.value)}
+        placeholder="Find"
+        className="px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        style={{ width: "200px" }}
+      />
+      <button
+        onClick={findPrevious}
+        disabled={!searchText}
+        className="px-2 py-1 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+        title="Previous (Shift+Enter)"
+      >
+        ↑
+      </button>
+      <button
+        onClick={findNext}
+        disabled={!searchText}
+        className="px-2 py-1 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+        title="Next (Enter)"
+      >
+        ↓
+      </button>
+      <button
+        onClick={handleClose}
+        className="px-2 py-1 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+        title="Close (Escape)"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -75,6 +75,16 @@ declare global {
         clear: () => Promise<{ success: boolean; error?: string }>;
       };
 
+      find: {
+        search: (
+          text: string,
+          options?: { forward?: boolean; findNext?: boolean },
+        ) => void;
+        stop: (
+          action?: "clearSelection" | "keepSelection" | "activateSelection",
+        ) => void;
+      };
+
       on: (
         channel: string,
         callback: (event: IpcRendererEvent, ...args: any[]) => void,


### PR DESCRIPTION
Enable native Electron find-in-page functionality to provide the expected Cmd/Ctrl+F search experience.

While Electron provides a native `findInPage` API for search and highlighting, it does not include a built-in visual find bar UI. Therefore, a minimal custom UI component was implemented to expose this functionality to the user, similar to how other Electron apps (e.g., VS Code) handle it.

---
<a href="https://cursor.com/background-agent?bcId=bc-165fae96-cbdb-4a5d-8655-cbc8bf746971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-165fae96-cbdb-4a5d-8655-cbc8bf746971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



Relates to #32

Fixes #32