### PR TITLE
Enable native find in page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bottleneck",
-  "version": "0.1.8",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bottleneck",
-      "version": "0.1.8",
+      "version": "0.1.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -155,6 +155,35 @@ function createWindow() {
   // Set up application menu
   const menu = createMenu(mainWindow);
   Menu.setApplicationMenu(menu);
+
+  // Enable native find-in-page functionality with keyboard shortcuts
+  let findActive = false;
+  
+  mainWindow.webContents.on("before-input-event", (event, input) => {
+    // Handle Cmd/Ctrl+F to start find
+    if (input.type === "keyDown" && input.key === "f" && (input.control || input.meta)) {
+      event.preventDefault();
+      // Start find with empty string to show the find interface
+      mainWindow?.webContents.findInPage("");
+      findActive = true;
+    }
+    // Handle Escape to stop find
+    else if (input.type === "keyDown" && input.key === "Escape" && findActive) {
+      event.preventDefault();
+      mainWindow?.webContents.stopFindInPage("clearSelection");
+      findActive = false;
+    }
+    // Handle Enter for find next (when find is active)
+    else if (input.type === "keyDown" && input.key === "Enter" && findActive && !input.shift) {
+      event.preventDefault();
+      mainWindow?.webContents.findInPage("", { forward: true, findNext: true });
+    }
+    // Handle Shift+Enter for find previous (when find is active)
+    else if (input.type === "keyDown" && input.key === "Enter" && findActive && input.shift) {
+      event.preventDefault();
+      mainWindow?.webContents.findInPage("", { forward: false, findNext: true });
+    }
+  });
 }
 
 // App event handlers

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -81,6 +81,31 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
               { role: "selectAll" as const },
               { type: "separator" as const },
               {
+                label: "Find",
+                accelerator: "Cmd+F",
+                click: () => {
+                  // Start find with empty string to show find interface
+                  mainWindow.webContents.findInPage("");
+                },
+              },
+              {
+                label: "Find Next",
+                accelerator: "Cmd+G",
+                click: () => {
+                  // Find next occurrence
+                  mainWindow.webContents.findInPage("", { forward: true, findNext: true });
+                },
+              },
+              {
+                label: "Find Previous",
+                accelerator: "Cmd+Shift+G",
+                click: () => {
+                  // Find previous occurrence
+                  mainWindow.webContents.findInPage("", { forward: false, findNext: true });
+                },
+              },
+              { type: "separator" as const },
+              {
                 label: "Speech",
                 submenu: [
                   { role: "startSpeaking" as const },
@@ -92,6 +117,31 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
               { role: "delete" as const },
               { type: "separator" as const },
               { role: "selectAll" as const },
+              { type: "separator" as const },
+              {
+                label: "Find",
+                accelerator: "Ctrl+F",
+                click: () => {
+                  // Start find with empty string to show find interface
+                  mainWindow.webContents.findInPage("");
+                },
+              },
+              {
+                label: "Find Next",
+                accelerator: "F3",
+                click: () => {
+                  // Find next occurrence
+                  mainWindow.webContents.findInPage("", { forward: true, findNext: true });
+                },
+              },
+              {
+                label: "Find Previous",
+                accelerator: "Shift+F3",
+                click: () => {
+                  // Find previous occurrence
+                  mainWindow.webContents.findInPage("", { forward: false, findNext: true });
+                },
+              },
             ]),
       ],
     },


### PR DESCRIPTION
Enable native Electron find-in-page functionality to allow users to search within the current page using standard keyboard shortcuts.

---
<a href="https://cursor.com/background-agent?bcId=bc-dda370a3-017c-4318-9185-f4d003b689c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dda370a3-017c-4318-9185-f4d003b689c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



Relates to #32

Fixes #32