### PR TITLE
Revamp issues tab to kanban issue tracker

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -19,7 +19,7 @@ const PRDetailView = lazy(() => import("./views/PRDetailView"));
 const BranchesView = lazy(() => import("./views/BranchesView"));
 const SettingsView = lazy(() => import("./views/SettingsView"));
 const AuthView = lazy(() => import("./views/AuthView"));
-const IssuesView = lazy(() => import("./views/IssuesView"));
+const IssueTrackerView = lazy(() => import("./views/IssueTrackerView"));
 const IssueDetailView = lazy(() => import("./views/IssueDetailView"));
 const CursorView = lazy(() => import("./views/CursorView"));
 const DevinView = lazy(() => import("./views/DevinView"));
@@ -180,7 +180,7 @@ function App() {
                 element={<PRDetailView />}
               />
               <Route path="/branches" element={<BranchesView />} />
-              <Route path="/issues" element={<IssuesView />} />
+              <Route path="/issues" element={<IssueTrackerView />} />
               <Route
                 path="/issues/:owner/:repo/:number"
                 element={<IssueDetailView />}

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -24,7 +24,7 @@ interface SidebarProps {
 
 const NAV_ITEMS: SidebarNavItem[] = [
   { path: "/pulls", icon: GitPullRequest, label: "Pull Requests" },
-  { path: "/issues", icon: AlertCircle, label: "Issues" },
+  { path: "/issues", icon: AlertCircle, label: "Issue Tracker" },
   { path: "/branches", icon: GitBranch, label: "Branches" },
   {
     icon: SatelliteDish,

--- a/src/renderer/components/kanban/IssueCard.tsx
+++ b/src/renderer/components/kanban/IssueCard.tsx
@@ -1,0 +1,189 @@
+import React from "react";
+import { cn } from "../../utils/cn";
+import { Issue } from "../../services/github";
+import { MessageSquare, GitBranch, GitPullRequest, CheckCircle2, Edit } from "lucide-react";
+import { getLabelColors } from "../../utils/labelColors";
+import { formatDistanceToNow } from "date-fns";
+
+interface IssueCardProps {
+  issue: Issue;
+  theme: "light" | "dark";
+  relatedPRs?: Array<{ number: number; state: string; merged: boolean }>;
+  onDragStart?: (e: React.DragEvent, issue: Issue) => void;
+  onEditClick?: (e: React.MouseEvent, issue: Issue) => void;
+}
+
+export const IssueCard: React.FC<IssueCardProps> = ({
+  issue,
+  theme,
+  relatedPRs = [],
+  onDragStart,
+  onEditClick,
+}) => {
+  const handleDragStart = (e: React.DragEvent) => {
+    e.dataTransfer.effectAllowed = "move";
+    e.dataTransfer.setData("application/json", JSON.stringify(issue));
+    if (onDragStart) {
+      onDragStart(e, issue);
+    }
+  };
+
+  const handleEditClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (onEditClick) {
+      onEditClick(e, issue);
+    }
+  };
+
+  const openPRs = relatedPRs.filter(pr => pr.state === "open" && !pr.merged);
+  const mergedPRs = relatedPRs.filter(pr => pr.merged);
+
+  return (
+    <div
+      draggable
+      onDragStart={handleDragStart}
+      className={cn(
+        "p-3 rounded-md border cursor-move transition-all hover:shadow-md relative group",
+        theme === "dark"
+          ? "bg-gray-900 border-gray-700 hover:border-gray-600"
+          : "bg-white border-gray-200 hover:border-gray-300"
+      )}
+    >
+      {/* Edit Button */}
+      <button
+        onClick={handleEditClick}
+        className={cn(
+          "absolute top-2 right-2 p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity",
+          theme === "dark"
+            ? "bg-gray-800 hover:bg-gray-700 text-gray-300"
+            : "bg-gray-100 hover:bg-gray-200 text-gray-600"
+        )}
+        title="Edit issue"
+      >
+        <Edit className="w-3 h-3" />
+      </button>
+
+      {/* Issue Title */}
+      <h4
+        className={cn(
+          "text-sm font-medium mb-2 line-clamp-2 pr-6",
+          theme === "dark" ? "text-gray-100" : "text-gray-900"
+        )}
+      >
+        {issue.title}
+      </h4>
+
+      {/* Issue Number and Metadata */}
+      <div className="flex items-center justify-between mb-2">
+        <span
+          className={cn(
+            "text-xs",
+            theme === "dark" ? "text-gray-400" : "text-gray-500"
+          )}
+        >
+          #{issue.number}
+        </span>
+        <span
+          className={cn(
+            "text-xs",
+            theme === "dark" ? "text-gray-400" : "text-gray-500"
+          )}
+        >
+          {formatDistanceToNow(new Date(issue.updated_at), { addSuffix: true })}
+        </span>
+      </div>
+
+      {/* Labels */}
+      {issue.labels.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-2">
+          {issue.labels.slice(0, 3).map((label) => {
+            const labelColors = getLabelColors(label.color, theme);
+            return (
+              <span
+                key={label.name}
+                className="px-1.5 py-0.5 text-xs rounded font-medium"
+                style={{
+                  backgroundColor: labelColors.backgroundColor,
+                  color: labelColors.color,
+                }}
+              >
+                {label.name}
+              </span>
+            );
+          })}
+          {issue.labels.length > 3 && (
+            <span
+              className={cn(
+                "px-1.5 py-0.5 text-xs rounded",
+                theme === "dark" ? "bg-gray-700 text-gray-300" : "bg-gray-200 text-gray-600"
+              )}
+            >
+              +{issue.labels.length - 3}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Footer - Assignees and Stats */}
+      <div className="flex items-center justify-between mt-3 pt-2 border-t border-gray-700/30">
+        <div className="flex items-center space-x-2">
+          {/* Assignees */}
+          {issue.assignees.length > 0 && (
+            <div className="flex -space-x-1">
+              {issue.assignees.slice(0, 3).map((assignee) => (
+                <img
+                  key={assignee.login}
+                  src={assignee.avatar_url}
+                  alt={assignee.login}
+                  className={cn(
+                    "w-5 h-5 rounded-full border",
+                    theme === "dark" ? "border-gray-800" : "border-white"
+                  )}
+                  title={assignee.login}
+                />
+              ))}
+              {issue.assignees.length > 3 && (
+                <div
+                  className={cn(
+                    "w-5 h-5 rounded-full border flex items-center justify-center text-xs font-medium",
+                    theme === "dark"
+                      ? "bg-gray-700 border-gray-800 text-gray-300"
+                      : "bg-gray-200 border-white text-gray-600"
+                  )}
+                >
+                  +{issue.assignees.length - 3}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center space-x-2 text-xs">
+          {/* Comments */}
+          {issue.comments > 0 && (
+            <div className="flex items-center space-x-1">
+              <MessageSquare className="w-3 h-3" />
+              <span>{issue.comments}</span>
+            </div>
+          )}
+
+          {/* Related PRs */}
+          {openPRs.length > 0 && (
+            <div className="flex items-center space-x-1 text-blue-400">
+              <GitPullRequest className="w-3 h-3" />
+              <span>{openPRs.length}</span>
+            </div>
+          )}
+
+          {/* Merged PRs */}
+          {mergedPRs.length > 0 && (
+            <div className="flex items-center space-x-1 text-purple-400">
+              <CheckCircle2 className="w-3 h-3" />
+              <span>{mergedPRs.length}</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/components/kanban/IssueEditModal.tsx
+++ b/src/renderer/components/kanban/IssueEditModal.tsx
@@ -1,0 +1,376 @@
+import React, { useState, useEffect } from "react";
+import { X, User, Tag, CheckCircle, XCircle, GitPullRequest } from "lucide-react";
+import { cn } from "../../utils/cn";
+import { Issue } from "../../services/github";
+import { getLabelColors } from "../../utils/labelColors";
+
+interface IssueEditModalProps {
+  issue: Issue;
+  theme: "light" | "dark";
+  isOpen: boolean;
+  onClose: () => void;
+  onUpdateAssignees: (assignees: string[]) => Promise<void>;
+  onUpdateLabels: (labels: string[]) => Promise<void>;
+  onCloseIssue: () => Promise<void>;
+  onReopen: () => Promise<void>;
+  availableLabels: Array<{ name: string; color: string; description: string | null }>;
+  relatedPRs?: Array<{ number: number; title: string; state: string; merged: boolean }>;
+}
+
+export const IssueEditModal: React.FC<IssueEditModalProps> = ({
+  issue,
+  theme,
+  isOpen,
+  onClose,
+  onUpdateAssignees,
+  onUpdateLabels,
+  onCloseIssue,
+  onReopen,
+  availableLabels,
+  relatedPRs = [],
+}) => {
+  const [selectedLabels, setSelectedLabels] = useState<string[]>(
+    issue.labels.map((l) => l.name)
+  );
+  const [assigneeInput, setAssigneeInput] = useState("");
+  const [assignees, setAssignees] = useState<string[]>(
+    issue.assignees.map((a) => a.login)
+  );
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedLabels(issue.labels.map((l) => l.name));
+      setAssignees(issue.assignees.map((a) => a.login));
+    }
+  }, [isOpen, issue]);
+
+  if (!isOpen) return null;
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      // Update assignees if changed
+      const currentAssignees = issue.assignees.map((a) => a.login);
+      if (JSON.stringify(assignees.sort()) !== JSON.stringify(currentAssignees.sort())) {
+        await onUpdateAssignees(assignees);
+      }
+
+      // Update labels if changed
+      const currentLabels = issue.labels.map((l) => l.name);
+      if (JSON.stringify(selectedLabels.sort()) !== JSON.stringify(currentLabels.sort())) {
+        await onUpdateLabels(selectedLabels);
+      }
+
+      onClose();
+    } catch (error) {
+      console.error("Failed to save changes:", error);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleAddAssignee = () => {
+    if (assigneeInput.trim() && !assignees.includes(assigneeInput.trim())) {
+      setAssignees([...assignees, assigneeInput.trim()]);
+      setAssigneeInput("");
+    }
+  };
+
+  const handleRemoveAssignee = (assignee: string) => {
+    setAssignees(assignees.filter((a) => a !== assignee));
+  };
+
+  const handleToggleLabel = (labelName: string) => {
+    if (selectedLabels.includes(labelName)) {
+      setSelectedLabels(selectedLabels.filter((l) => l !== labelName));
+    } else {
+      setSelectedLabels([...selectedLabels, labelName]);
+    }
+  };
+
+  const handleCloseIssue = async () => {
+    setSaving(true);
+    try {
+      await onCloseIssue();
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReopenIssue = async () => {
+    setSaving(true);
+    try {
+      await onReopen();
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className={cn(
+          "w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-lg shadow-xl",
+          theme === "dark" ? "bg-gray-800" : "bg-white"
+        )}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div
+          className={cn(
+            "flex items-center justify-between p-4 border-b",
+            theme === "dark" ? "border-gray-700" : "border-gray-200"
+          )}
+        >
+          <div>
+            <h2
+              className={cn(
+                "text-lg font-semibold",
+                theme === "dark" ? "text-gray-100" : "text-gray-900"
+              )}
+            >
+              Edit Issue #{issue.number}
+            </h2>
+            <p
+              className={cn(
+                "text-sm mt-1",
+                theme === "dark" ? "text-gray-400" : "text-gray-600"
+              )}
+            >
+              {issue.title}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className={cn(
+              "p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700",
+              theme === "dark" ? "text-gray-400" : "text-gray-600"
+            )}
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-4 space-y-6">
+          {/* Assignees Section */}
+          <div>
+            <div className="flex items-center space-x-2 mb-3">
+              <User className="w-4 h-4" />
+              <h3
+                className={cn(
+                  "font-medium text-sm",
+                  theme === "dark" ? "text-gray-200" : "text-gray-700"
+                )}
+              >
+                Assignees
+              </h3>
+            </div>
+            <div className="space-y-2">
+              {assignees.map((assignee) => (
+                <div
+                  key={assignee}
+                  className={cn(
+                    "flex items-center justify-between px-3 py-2 rounded",
+                    theme === "dark" ? "bg-gray-700" : "bg-gray-100"
+                  )}
+                >
+                  <span className="text-sm">{assignee}</span>
+                  <button
+                    onClick={() => handleRemoveAssignee(assignee)}
+                    className="text-red-500 hover:text-red-600"
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
+                </div>
+              ))}
+              <div className="flex space-x-2">
+                <input
+                  type="text"
+                  value={assigneeInput}
+                  onChange={(e) => setAssigneeInput(e.target.value)}
+                  onKeyPress={(e) => e.key === "Enter" && handleAddAssignee()}
+                  placeholder="Enter GitHub username"
+                  className={cn(
+                    "flex-1 px-3 py-2 rounded border text-sm",
+                    theme === "dark"
+                      ? "bg-gray-700 border-gray-600 text-gray-100"
+                      : "bg-white border-gray-300 text-gray-900"
+                  )}
+                />
+                <button
+                  onClick={handleAddAssignee}
+                  className={cn(
+                    "px-4 py-2 rounded text-sm font-medium",
+                    theme === "dark"
+                      ? "bg-blue-600 hover:bg-blue-700 text-white"
+                      : "bg-blue-500 hover:bg-blue-600 text-white"
+                  )}
+                >
+                  Add
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* Labels Section */}
+          <div>
+            <div className="flex items-center space-x-2 mb-3">
+              <Tag className="w-4 h-4" />
+              <h3
+                className={cn(
+                  "font-medium text-sm",
+                  theme === "dark" ? "text-gray-200" : "text-gray-700"
+                )}
+              >
+                Labels
+              </h3>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {availableLabels.map((label) => {
+                const isSelected = selectedLabels.includes(label.name);
+                const labelColors = getLabelColors(label.color, theme);
+                return (
+                  <button
+                    key={label.name}
+                    onClick={() => handleToggleLabel(label.name)}
+                    className={cn(
+                      "px-2 py-1 text-xs rounded font-medium transition-all",
+                      isSelected
+                        ? "ring-2 ring-blue-500 ring-offset-2"
+                        : "opacity-60 hover:opacity-100"
+                    )}
+                    style={{
+                      backgroundColor: labelColors.backgroundColor,
+                      color: labelColors.color,
+                    }}
+                  >
+                    {label.name}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Related PRs Section */}
+          {relatedPRs.length > 0 && (
+            <div>
+              <div className="flex items-center space-x-2 mb-3">
+                <GitPullRequest className="w-4 h-4" />
+                <h3
+                  className={cn(
+                    "font-medium text-sm",
+                    theme === "dark" ? "text-gray-200" : "text-gray-700"
+                  )}
+                >
+                  Related Pull Requests
+                </h3>
+              </div>
+              <div className="space-y-2">
+                {relatedPRs.map((pr) => (
+                  <div
+                    key={pr.number}
+                    className={cn(
+                      "px-3 py-2 rounded flex items-center justify-between",
+                      theme === "dark" ? "bg-gray-700" : "bg-gray-100"
+                    )}
+                  >
+                    <span className="text-sm">
+                      #{pr.number}: {pr.title}
+                    </span>
+                    <span
+                      className={cn(
+                        "text-xs px-2 py-0.5 rounded",
+                        pr.merged
+                          ? "bg-purple-500 text-white"
+                          : pr.state === "open"
+                          ? "bg-green-500 text-white"
+                          : "bg-red-500 text-white"
+                      )}
+                    >
+                      {pr.merged ? "Merged" : pr.state}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Issue State Actions */}
+          <div className="flex space-x-2 pt-4 border-t border-gray-700">
+            {issue.state === "open" ? (
+              <button
+                onClick={handleCloseIssue}
+                disabled={saving}
+                className={cn(
+                  "flex items-center space-x-2 px-4 py-2 rounded text-sm font-medium",
+                  theme === "dark"
+                    ? "bg-purple-600 hover:bg-purple-700 text-white"
+                    : "bg-purple-500 hover:bg-purple-600 text-white",
+                  saving && "opacity-50 cursor-not-allowed"
+                )}
+              >
+                <XCircle className="w-4 h-4" />
+                <span>Close Issue</span>
+              </button>
+            ) : (
+              <button
+                onClick={handleReopenIssue}
+                disabled={saving}
+                className={cn(
+                  "flex items-center space-x-2 px-4 py-2 rounded text-sm font-medium",
+                  theme === "dark"
+                    ? "bg-green-600 hover:bg-green-700 text-white"
+                    : "bg-green-500 hover:bg-green-600 text-white",
+                  saving && "opacity-50 cursor-not-allowed"
+                )}
+              >
+                <CheckCircle className="w-4 h-4" />
+                <span>Reopen Issue</span>
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div
+          className={cn(
+            "flex items-center justify-end space-x-3 p-4 border-t",
+            theme === "dark" ? "border-gray-700" : "border-gray-200"
+          )}
+        >
+          <button
+            onClick={onClose}
+            className={cn(
+              "px-4 py-2 rounded text-sm font-medium",
+              theme === "dark"
+                ? "bg-gray-700 hover:bg-gray-600 text-gray-200"
+                : "bg-gray-200 hover:bg-gray-300 text-gray-700"
+            )}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className={cn(
+              "px-4 py-2 rounded text-sm font-medium",
+              theme === "dark"
+                ? "bg-blue-600 hover:bg-blue-700 text-white"
+                : "bg-blue-500 hover:bg-blue-600 text-white",
+              saving && "opacity-50 cursor-not-allowed"
+            )}
+          >
+            {saving ? "Saving..." : "Save Changes"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/components/kanban/KanbanColumn.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { cn } from "../../utils/cn";
+import { Issue } from "../../services/github";
+
+interface KanbanColumnProps {
+  title: string;
+  count: number;
+  issues: Issue[];
+  theme: "light" | "dark";
+  onDrop: (issue: Issue) => void;
+  onIssueClick: (issue: Issue) => void;
+  renderIssueCard: (issue: Issue) => React.ReactNode;
+  columnId: string;
+}
+
+export const KanbanColumn: React.FC<KanbanColumnProps> = ({
+  title,
+  count,
+  issues,
+  theme,
+  onDrop,
+  onIssueClick,
+  renderIssueCard,
+  columnId,
+}) => {
+  const [isDragOver, setIsDragOver] = React.useState(false);
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(true);
+  };
+
+  const handleDragLeave = () => {
+    setIsDragOver(false);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+    
+    const issueData = e.dataTransfer.getData("application/json");
+    if (issueData) {
+      try {
+        const issue = JSON.parse(issueData);
+        onDrop(issue);
+      } catch (error) {
+        console.error("Failed to parse dropped issue:", error);
+      }
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col rounded-lg border min-w-[300px] flex-1",
+        theme === "dark" ? "bg-gray-800 border-gray-700" : "bg-gray-50 border-gray-200"
+      )}
+    >
+      {/* Column Header */}
+      <div
+        className={cn(
+          "px-4 py-3 border-b font-medium",
+          theme === "dark" ? "border-gray-700" : "border-gray-200"
+        )}
+      >
+        <div className="flex items-center justify-between">
+          <span className={cn(
+            "text-sm font-semibold",
+            theme === "dark" ? "text-gray-200" : "text-gray-700"
+          )}>
+            {title}
+          </span>
+          <span className={cn(
+            "text-xs px-2 py-0.5 rounded-full",
+            theme === "dark" ? "bg-gray-700 text-gray-300" : "bg-gray-200 text-gray-600"
+          )}>
+            {count}
+          </span>
+        </div>
+      </div>
+
+      {/* Column Body */}
+      <div
+        className={cn(
+          "flex-1 p-3 space-y-2 overflow-y-auto min-h-[200px]",
+          isDragOver && (theme === "dark" ? "bg-gray-700/50" : "bg-gray-100/50")
+        )}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        data-column-id={columnId}
+      >
+        {issues.length === 0 ? (
+          <div className={cn(
+            "flex items-center justify-center h-32 text-sm",
+            theme === "dark" ? "text-gray-500" : "text-gray-400"
+          )}>
+            No issues
+          </div>
+        ) : (
+          issues.map((issue) => (
+            <div key={issue.id} onClick={() => onIssueClick(issue)}>
+              {renderIssueCard(issue)}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/views/IssueTrackerView.tsx
+++ b/src/renderer/views/IssueTrackerView.tsx
@@ -1,0 +1,378 @@
+import React, { useEffect, useState, useMemo, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { Kanban, RefreshCw } from "lucide-react";
+import { useIssueStore } from "../stores/issueStore";
+import { usePRStore } from "../stores/prStore";
+import { useUIStore } from "../stores/uiStore";
+import { cn } from "../utils/cn";
+import WelcomeView from "./WelcomeView";
+import { Issue } from "../services/github";
+import { KanbanColumn } from "../components/kanban/KanbanColumn";
+import { IssueCard } from "../components/kanban/IssueCard";
+import { IssueEditModal } from "../components/kanban/IssueEditModal";
+
+type KanbanColumnType = "unassigned" | "todo" | "in-progress" | "in-review" | "done" | "closed";
+
+interface KanbanColumnData {
+  id: KanbanColumnType;
+  title: string;
+  issues: Issue[];
+}
+
+export default function IssueTrackerView() {
+  const navigate = useNavigate();
+  const {
+    issues,
+    issuesMetadata,
+    loading,
+    fetchIssues,
+    fetchIssueMetadata,
+    assignIssue,
+    unassignIssue,
+    closeIssues,
+    reopenIssues,
+    repoLabels,
+    fetchRepoLabels,
+    addLabelsToIssues,
+    removeLabelsFromIssues,
+  } = useIssueStore();
+  const { selectedRepo } = usePRStore();
+  const { theme } = useUIStore();
+  const [loadingMetadata, setLoadingMetadata] = useState(false);
+  const [editingIssue, setEditingIssue] = useState<Issue | null>(null);
+
+  // Fetch issues and labels when repo changes
+  useEffect(() => {
+    if (selectedRepo) {
+      fetchIssues(selectedRepo.owner, selectedRepo.name);
+      fetchRepoLabels(selectedRepo.owner, selectedRepo.name);
+    }
+  }, [selectedRepo, fetchIssues, fetchRepoLabels]);
+
+  // Fetch metadata for all issues (related PRs)
+  useEffect(() => {
+    if (selectedRepo && issues.size > 0 && !loadingMetadata) {
+      setLoadingMetadata(true);
+      const issuesList = Array.from(issues.values());
+      
+      // Fetch metadata for all issues in batches
+      Promise.all(
+        issuesList.map((issue) =>
+          fetchIssueMetadata(selectedRepo.owner, selectedRepo.name, issue.number)
+        )
+      ).finally(() => {
+        setLoadingMetadata(false);
+      });
+    }
+  }, [selectedRepo, issues.size]);
+
+  // Categorize issues into Kanban columns
+  const kanbanColumns = useMemo((): KanbanColumnData[] => {
+    const issuesList = Array.from(issues.values());
+
+    const unassigned: Issue[] = [];
+    const todo: Issue[] = [];
+    const inProgress: Issue[] = [];
+    const inReview: Issue[] = [];
+    const done: Issue[] = [];
+    const closed: Issue[] = [];
+
+    issuesList.forEach((issue) => {
+      const issueKey = `${selectedRepo?.owner}/${selectedRepo?.name}#${issue.number}`;
+      const metadata = issuesMetadata.get(issueKey);
+      const relatedPRs = metadata?.relatedPRs || [];
+
+      // Closed issues
+      if (issue.state === "closed") {
+        closed.push(issue);
+        return;
+      }
+
+      // Check if there are merged PRs
+      const hasMergedPR = relatedPRs.some((pr: any) => pr.merged);
+      if (hasMergedPR) {
+        done.push(issue);
+        return;
+      }
+
+      // Check if there are open PRs (In Review)
+      const hasOpenPR = relatedPRs.some((pr: any) => pr.state === "open" && !pr.merged);
+      if (hasOpenPR) {
+        inReview.push(issue);
+        return;
+      }
+
+      // Check if assigned or has related work (In Progress)
+      const hasAssignees = issue.assignees.length > 0;
+      const hasPRs = relatedPRs.length > 0;
+      if (hasAssignees || hasPRs) {
+        inProgress.push(issue);
+        return;
+      }
+
+      // Check if completely unassigned (no assignees AND no PRs/branches)
+      if (!hasAssignees && relatedPRs.length === 0) {
+        unassigned.push(issue);
+        return;
+      }
+
+      // Default: TODO
+      todo.push(issue);
+    });
+
+    return [
+      { id: "unassigned", title: "Unassigned", issues: unassigned },
+      { id: "todo", title: "TODO", issues: todo },
+      { id: "in-progress", title: "In Progress", issues: inProgress },
+      { id: "in-review", title: "In Review", issues: inReview },
+      { id: "done", title: "Done", issues: done },
+      { id: "closed", title: "Closed", issues: closed },
+    ];
+  }, [issues, issuesMetadata, selectedRepo]);
+
+  const handleIssueClick = useCallback(
+    (issue: Issue) => {
+      if (selectedRepo) {
+        navigate(
+          `/issues/${selectedRepo.owner}/${selectedRepo.name}/${issue.number}`
+        );
+      }
+    },
+    [navigate, selectedRepo]
+  );
+
+  const handleDrop = useCallback(
+    async (columnId: KanbanColumnType, issue: Issue) => {
+      if (!selectedRepo) return;
+
+      // Handle drag-and-drop logic based on the target column
+      try {
+        switch (columnId) {
+          case "unassigned":
+            // Remove all assignees
+            if (issue.assignees.length > 0) {
+              await unassignIssue(
+                selectedRepo.owner,
+                selectedRepo.name,
+                issue.number,
+                issue.assignees.map((a) => a.login)
+              );
+            }
+            break;
+
+          case "todo":
+            // No specific action - just ensure it's open
+            if (issue.state === "closed") {
+              await reopenIssues(selectedRepo.owner, selectedRepo.name, [issue.number]);
+            }
+            break;
+
+          case "in-progress":
+            // Could prompt user to assign someone or just ensure it's open
+            if (issue.state === "closed") {
+              await reopenIssues(selectedRepo.owner, selectedRepo.name, [issue.number]);
+            }
+            // If no assignees, could prompt to assign
+            break;
+
+          case "in-review":
+            // Would need to check if there's a PR - for now just ensure it's open
+            if (issue.state === "closed") {
+              await reopenIssues(selectedRepo.owner, selectedRepo.name, [issue.number]);
+            }
+            break;
+
+          case "done":
+            // Keep open but marked as done (this is typically when PR is merged)
+            break;
+
+          case "closed":
+            // Close the issue
+            if (issue.state === "open") {
+              await closeIssues(selectedRepo.owner, selectedRepo.name, [issue.number]);
+            }
+            break;
+        }
+
+        // Refresh issues after state change
+        await fetchIssues(selectedRepo.owner, selectedRepo.name, true);
+      } catch (error) {
+        console.error("Failed to update issue:", error);
+      }
+    },
+    [selectedRepo, assignIssue, unassignIssue, closeIssues, reopenIssues, fetchIssues]
+  );
+
+  const handleRefresh = useCallback(() => {
+    if (selectedRepo) {
+      fetchIssues(selectedRepo.owner, selectedRepo.name, true);
+    }
+  }, [selectedRepo, fetchIssues]);
+
+  const handleEditClick = useCallback((e: React.MouseEvent, issue: Issue) => {
+    e.stopPropagation();
+    setEditingIssue(issue);
+  }, []);
+
+  const handleUpdateAssignees = useCallback(
+    async (assignees: string[]) => {
+      if (!selectedRepo || !editingIssue) return;
+
+      const currentAssignees = editingIssue.assignees.map((a) => a.login);
+      const toAdd = assignees.filter((a) => !currentAssignees.includes(a));
+      const toRemove = currentAssignees.filter((a) => !assignees.includes(a));
+
+      if (toAdd.length > 0) {
+        await assignIssue(selectedRepo.owner, selectedRepo.name, editingIssue.number, toAdd);
+      }
+      if (toRemove.length > 0) {
+        await unassignIssue(selectedRepo.owner, selectedRepo.name, editingIssue.number, toRemove);
+      }
+
+      await fetchIssues(selectedRepo.owner, selectedRepo.name, true);
+    },
+    [selectedRepo, editingIssue, assignIssue, unassignIssue, fetchIssues]
+  );
+
+  const handleUpdateLabels = useCallback(
+    async (labels: string[]) => {
+      if (!selectedRepo || !editingIssue) return;
+
+      const currentLabels = editingIssue.labels.map((l) => l.name);
+      const toAdd = labels.filter((l) => !currentLabels.includes(l));
+      const toRemove = currentLabels.filter((l) => !labels.includes(l));
+
+      if (toAdd.length > 0) {
+        await addLabelsToIssues(selectedRepo.owner, selectedRepo.name, [editingIssue.number], toAdd);
+      }
+      if (toRemove.length > 0) {
+        await removeLabelsFromIssues(selectedRepo.owner, selectedRepo.name, [editingIssue.number], toRemove);
+      }
+
+      await fetchIssues(selectedRepo.owner, selectedRepo.name, true);
+    },
+    [selectedRepo, editingIssue, addLabelsToIssues, removeLabelsFromIssues, fetchIssues]
+  );
+
+  const handleCloseIssue = useCallback(async () => {
+    if (!selectedRepo || !editingIssue) return;
+    await closeIssues(selectedRepo.owner, selectedRepo.name, [editingIssue.number]);
+    await fetchIssues(selectedRepo.owner, selectedRepo.name, true);
+  }, [selectedRepo, editingIssue, closeIssues, fetchIssues]);
+
+  const handleReopenIssue = useCallback(async () => {
+    if (!selectedRepo || !editingIssue) return;
+    await reopenIssues(selectedRepo.owner, selectedRepo.name, [editingIssue.number]);
+    await fetchIssues(selectedRepo.owner, selectedRepo.name, true);
+  }, [selectedRepo, editingIssue, reopenIssues, fetchIssues]);
+
+  if (!selectedRepo) {
+    return <WelcomeView />;
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div
+        className={cn(
+          "p-4 border-b",
+          theme === "dark"
+            ? "bg-gray-800 border-gray-700"
+            : "bg-gray-50 border-gray-200"
+        )}
+      >
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-3">
+            <Kanban className="w-5 h-5" />
+            <h1 className="text-xl font-semibold">Issue Tracker</h1>
+            <span
+              className={cn(
+                "text-sm",
+                theme === "dark" ? "text-gray-500" : "text-gray-600"
+              )}
+            >
+              ({Array.from(issues.values()).length} issues)
+            </span>
+          </div>
+
+          <button
+            onClick={handleRefresh}
+            disabled={loading}
+            className={cn(
+              "flex items-center space-x-2 px-3 py-1.5 rounded text-sm font-medium transition-colors",
+              theme === "dark"
+                ? "bg-gray-700 hover:bg-gray-600 text-gray-200"
+                : "bg-gray-200 hover:bg-gray-300 text-gray-700",
+              loading && "opacity-50 cursor-not-allowed"
+            )}
+          >
+            <RefreshCw className={cn("w-4 h-4", loading && "animate-spin")} />
+            <span>Refresh</span>
+          </button>
+        </div>
+      </div>
+
+      {/* Kanban Board */}
+      <div className="flex-1 overflow-x-auto overflow-y-hidden p-4">
+        {loading && issues.size === 0 ? (
+          <div className="flex items-center justify-center h-full">
+            <div
+              className={cn(
+                "text-center",
+                theme === "dark" ? "text-gray-400" : "text-gray-600"
+              )}
+            >
+              Loading issues...
+            </div>
+          </div>
+        ) : (
+          <div className="flex space-x-4 h-full pb-4">
+            {kanbanColumns.map((column) => (
+              <KanbanColumn
+                key={column.id}
+                columnId={column.id}
+                title={column.title}
+                count={column.issues.length}
+                issues={column.issues}
+                theme={theme}
+                onDrop={(issue) => handleDrop(column.id, issue)}
+                onIssueClick={handleIssueClick}
+                renderIssueCard={(issue) => {
+                  const issueKey = `${selectedRepo.owner}/${selectedRepo.name}#${issue.number}`;
+                  const metadata = issuesMetadata.get(issueKey);
+                  return (
+                    <IssueCard
+                      issue={issue}
+                      theme={theme}
+                      relatedPRs={metadata?.relatedPRs}
+                      onEditClick={handleEditClick}
+                    />
+                  );
+                }}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Edit Modal */}
+      {editingIssue && selectedRepo && (
+        <IssueEditModal
+          issue={editingIssue}
+          theme={theme}
+          isOpen={!!editingIssue}
+          onClose={() => setEditingIssue(null)}
+          onUpdateAssignees={handleUpdateAssignees}
+          onUpdateLabels={handleUpdateLabels}
+          onCloseIssue={handleCloseIssue}
+          onReopen={handleReopenIssue}
+          availableLabels={repoLabels}
+          relatedPRs={
+            issuesMetadata.get(`${selectedRepo.owner}/${selectedRepo.name}#${editingIssue.number}`)
+              ?.relatedPRs || []
+          }
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Overhaul the Issues tab into a Kanban-based Issue Tracker to provide a visual, interactive workflow for managing GitHub issues with drag-and-drop and inline editing.

The previous Issues tab was a simple list. This PR transforms it into a dynamic Kanban board, allowing users to categorize issues into "Unassigned", "TODO", "In Progress", "In Review", "Done", and "Closed" columns. This improves issue visibility and management by leveraging GitHub's assignees, PR status, and issue state to automatically categorize and allow direct manipulation of issue status via drag-and-drop and an edit modal.

---
<a href="https://cursor.com/background-agent?bcId=bc-74173a7c-54eb-4400-913b-071f6eaaeaac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-74173a7c-54eb-4400-913b-071f6eaaeaac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

Fixes #155