### PR TITLE
Build project and handle monaco editor error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bottleneck",
-  "version": "0.1.10",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bottleneck",
-      "version": "0.1.10",
+      "version": "0.1.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     monacoEditorPlugin({
       languageWorkers: ["editorWorkerService", "typescript", "json"],
       customWorkers: [],
+      publicPath: "monacoeditorwork",
     }),
   ],
   base: "./",


### PR DESCRIPTION
Fix Monaco Editor build failure by correcting the `publicPath` configuration in `vite.config.ts`.

The build was failing with an `ENOENT` error due to `vite-plugin-monaco-editor` incorrectly constructing paths for worker files when a custom `root` was used in Vite. Adding `publicPath: "monacoeditorwork"` resolves this by ensuring the plugin uses a correct relative path.

---
<a href="https://cursor.com/background-agent?bcId=bc-b7b5dbac-2641-4d47-9383-f0e9c2e23d1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b7b5dbac-2641-4d47-9383-f0e9c2e23d1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

