### PR TITLE
Build project and handle monaco editor error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bottleneck",
-  "version": "0.1.10",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bottleneck",
-      "version": "0.1.10",
+      "version": "0.1.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     monacoEditorPlugin({
       languageWorkers: ["editorWorkerService", "typescript", "json"],
       customWorkers: [],
+      publicPath: "./",
     }),
   ],
   base: "./",


### PR DESCRIPTION
Fix Monaco Editor build error by configuring `publicPath` in `vite.config.ts`.

The `vite-plugin-monaco-editor` was incorrectly concatenating absolute paths when creating the Monaco Editor worker directory, resulting in an `ENOENT` error during the build. Specifying `publicPath: "./"` ensures the plugin resolves paths correctly relative to the output directory, resolving the build failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb810824-d359-4bde-81f3-1a98f9325c22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fb810824-d359-4bde-81f3-1a98f9325c22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

