### PR TITLE
Build project and handle monaco editor error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,10 @@ export default defineConfig({
   base: "./",
   root: path.resolve(__dirname, "src/renderer"),
   build: {
-    outDir: path.resolve(__dirname, "dist/renderer"),
+    // Use a path relative to the Vite root to avoid Windows path
+    // concatenation issues in vite-plugin-monaco-editor
+    // (absolute outDir may be joined with root incorrectly on Windows)
+    outDir: "../../dist/renderer",
     emptyOutDir: true,
     sourcemap: false,
     minify: "esbuild",


### PR DESCRIPTION
Make Vite's renderer `outDir` relative to fix a Monaco editor plugin build error on Windows.

The `vite-plugin-monaco-editor` was failing to create a directory due to an invalid path concatenation on Windows (e.g., `src/renderer/dist/renderer/monacoeditorwork`). This occurred because the absolute `outDir` was being incorrectly joined with the Vite root. Changing `outDir` to a relative path resolves this issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-9fb32ed5-7c0a-4ba0-a4dd-73ca5f3515d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9fb32ed5-7c0a-4ba0-a4dd-73ca5f3515d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

