### PR TITLE
Build project for distribution

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,9 @@ export default defineConfig({
     monacoEditorPlugin({
       languageWorkers: ["editorWorkerService", "typescript", "json"],
       customWorkers: [],
-      publicPath: "./",
+      publicPath: "monacoeditorwork",
+      // Fix for Windows path issues - use relative path
+      filename: (name) => `monacoeditorwork/${name}.js`,
     }),
   ],
   base: "./",


### PR DESCRIPTION
Fix `vite-plugin-monaco-editor` build error on Windows by adjusting its public path configuration.

The `vite-plugin-monaco-editor` was generating incorrect directory paths for Monaco editor workers, leading to an `ENOENT` error during the build process on Windows. Adjusting `publicPath` and adding a `filename` function resolves this by ensuring correct relative path construction.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b12740d-f9f8-4dd7-99d1-1fe88e3b6fe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0b12740d-f9f8-4dd7-99d1-1fe88e3b6fe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

Fixes #163