### PR TITLE
Build project for distribution

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,13 +9,13 @@ export default defineConfig({
     monacoEditorPlugin({
       languageWorkers: ["editorWorkerService", "typescript", "json"],
       customWorkers: [],
-      publicPath: "./",
+      publicPath: "./monacoeditorwork/",
     }),
   ],
   base: "./",
   root: path.resolve(__dirname, "src/renderer"),
   build: {
-    outDir: path.resolve(__dirname, "dist/renderer"),
+    outDir: "../../dist/renderer",
     emptyOutDir: true,
     sourcemap: false,
     minify: "esbuild",


### PR DESCRIPTION
Fixes build failure caused by `vite-plugin-monaco-editor` by adjusting Vite's `outDir` and Monaco plugin's `publicPath` to use relative paths.

The `vite-plugin-monaco-editor` was failing to create necessary directories during the build process because Vite's `outDir` was configured as an absolute path. This led to incorrect path concatenation within the plugin, resulting in a malformed directory path. Changing `outDir` to a relative path resolves this issue. The `publicPath` for the monaco editor plugin was also adjusted to ensure its assets are correctly resolved with the new relative output structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-df3f49a0-fc1a-4075-871e-a2b9b5ed7c2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-df3f49a0-fc1a-4075-871e-a2b9b5ed7c2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

Fixes #163