### PR TITLE
Build project for distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "npm run build:main && npm run build:preload && npm run build:renderer",
     "build:main": "tsc -p tsconfig.main.json",
     "build:preload": "tsc -p tsconfig.preload.json",
-    "build:renderer": "vite build",
+    "build:renderer": "vite build --config vite.config.ts",
     "electron": "electron .",
     "start": "npm run build && npm run electron",
     "dist": "npm run build && electron-builder",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       languageWorkers: ["editorWorkerService", "typescript", "json"],
       customWorkers: [],
       publicPath: "./",
+      globalAPI: true,
     }),
   ],
   base: "./",


### PR DESCRIPTION
Fix Monaco Editor plugin build error to enable successful `npm run dist`.

The Monaco Editor plugin was failing to create a directory due to an invalid path concatenation. Adding `globalAPI: true` to the plugin configuration resolves this by ensuring correct path handling. Additionally, explicitly passing the config file to `vite build` ensures Vite uses the correct configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-31e9a272-b77c-4583-8bd5-c90e456e8b90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-31e9a272-b77c-4583-8bd5-c90e456e8b90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

Fixes #163