### PR TITLE
Build project for distribution

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,10 @@ export default defineConfig({
   base: "./",
   root: path.resolve(__dirname, "src/renderer"),
   build: {
-    outDir: path.resolve(__dirname, "dist/renderer"),
+    // Use a path relative to the Vite root so plugins that
+    // naively concatenate root and outDir don't produce invalid
+    // paths on Windows CI (e.g. "root\\D:\\...").
+    outDir: "../../dist/renderer",
     emptyOutDir: true,
     sourcemap: false,
     minify: "esbuild",


### PR DESCRIPTION
Fix build failure on Windows CI by making Vite's `outDir` relative to prevent incorrect path concatenation by plugins.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe0394dc-dd26-482f-bfaf-ba1a1767c15c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fe0394dc-dd26-482f-bfaf-ba1a1767c15c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

Fixes #163