### PR TITLE
Build project for distribution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,6 @@
         "vite": "^5.0.11",
         "vite-plugin-electron": "^0.15.5",
         "vite-plugin-electron-renderer": "^0.14.5",
-        "vite-plugin-monaco-editor": "^1.1.0",
         "vitest": "^3.2.4",
         "zustand": "^4.4.7"
       }
@@ -13834,16 +13833,6 @@
       "integrity": "sha512-oqkWFa7kQIkvHXG7+Mnl1RTroA4sP0yesKatmAy0gjZC4VwUqlvF9IvOpHd1fpLWsqYX/eZlVxlhULNtaQ78Jw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/vite-plugin-monaco-editor": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-monaco-editor/-/vite-plugin-monaco-editor-1.1.0.tgz",
-      "integrity": "sha512-IvtUqZotrRoVqwT0PBBDIZPNraya3BxN/bfcNfnxZ5rkJiGcNtO5eAOWWSgT7zullIAEqQwxMU83yL9J5k7gww==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "monaco-editor": ">=0.33.0"
-      }
     },
     "node_modules/vitest": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "vite": "^5.0.11",
     "vite-plugin-electron": "^0.15.5",
     "vite-plugin-electron-renderer": "^0.14.5",
-    "vite-plugin-monaco-editor": "^1.1.0",
     "vitest": "^3.2.4",
     "zustand": "^4.4.7"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,16 +1,10 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
-import monacoEditorPlugin from "vite-plugin-monaco-editor";
 
 export default defineConfig({
   plugins: [
     react(),
-    monacoEditorPlugin({
-      languageWorkers: ["editorWorkerService", "typescript", "json"],
-      customWorkers: [],
-      publicPath: "./",
-    }),
   ],
   base: "./",
   root: path.resolve(__dirname, "src/renderer"),


### PR DESCRIPTION
Remove `vite-plugin-monaco-editor` as it caused build failures and was redundant.

The `vite-plugin-monaco-editor` plugin was causing build failures due to incorrect path resolution, specifically concatenating paths in a malformed way on Windows. Since `@monaco-editor/react` is already used to load Monaco Editor via CDN, the plugin was redundant and could be safely removed.

---
<a href="https://cursor.com/background-agent?bcId=bc-a58024ca-65d1-4ec1-9e91-772b4e0cc9dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a58024ca-65d1-4ec1-9e91-772b4e0cc9dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

Fixes #163