### PR TITLE
Build project for distribution

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,10 @@ export default defineConfig({
   base: "./",
   root: path.resolve(__dirname, "src/renderer"),
   build: {
-    outDir: path.resolve(__dirname, "dist/renderer"),
+    // Use a path relative to the Vite root to avoid plugins
+    // constructing invalid absolute paths on Windows CI
+    // (previous absolute outDir caused src/renderer to be prefixed)
+    outDir: "../../dist/renderer",
     emptyOutDir: true,
     sourcemap: false,
     minify: "esbuild",


### PR DESCRIPTION
Update Vite `build.outDir` to a relative path to fix build errors on Windows CI.

The `vite-plugin-monaco-editor` was constructing an invalid absolute output directory path on Windows CI when `build.outDir` was also an absolute path, leading to an `ENOENT` error. Changing `outDir` to be relative to the Vite `root` resolves this path concatenation issue, allowing `npm run dist` to complete successfully.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e24afa0-d3fb-463a-800a-632e37d7d7be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6e24afa0-d3fb-463a-800a-632e37d7d7be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

Fixes #163